### PR TITLE
ctf-ir: disallow 0-bit integer, allow 1-bit signed integer

### DIFF
--- a/formats/ctf/ir/event-types.c
+++ b/formats/ctf/ir/event-types.c
@@ -359,7 +359,7 @@ struct bt_ctf_field_type *bt_ctf_field_type_integer_create(unsigned int size)
 	struct bt_ctf_field_type_integer *integer =
 		g_new0(struct bt_ctf_field_type_integer, 1);
 
-	if (!integer || size > 64) {
+	if (!integer || size == 0 || size > 64) {
 		return NULL;
 	}
 

--- a/formats/ctf/ir/event-types.c
+++ b/formats/ctf/ir/event-types.c
@@ -417,11 +417,6 @@ int bt_ctf_field_type_integer_set_signed(struct bt_ctf_field_type *type,
 	}
 
 	integer = container_of(type, struct bt_ctf_field_type_integer, parent);
-	if (is_signed && integer->declaration.len <= 1) {
-		ret = -1;
-		goto end;
-	}
-
 	integer->declaration.signedness = !!is_signed;
 end:
 	return ret;


### PR DESCRIPTION
Enforce a positive size on integer type creation, then signed or unsigned is possible for any size > 0.