### PR TITLE
Add basic object system to Babeltrace

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -5,7 +5,8 @@ babeltraceinclude_HEADERS = \
 	babeltrace/iterator.h \
 	babeltrace/trace-handle.h \
 	babeltrace/list.h \
-	babeltrace/clock-types.h
+	babeltrace/clock-types.h \
+	babeltrace/objects.h
 
 babeltracectfinclude_HEADERS = \
 	babeltrace/ctf/events.h \

--- a/include/babeltrace/objects.h
+++ b/include/babeltrace/objects.h
@@ -1,0 +1,878 @@
+#ifndef _BABELTRACE_OBJECTS_H
+#define _BABELTRACE_OBJECTS_H
+
+/*
+ * Babeltrace
+ *
+ * Basic object system
+ *
+ * Copyright (c) 2015 EfficiOS Inc. and Linux Foundation
+ * Copyright (c) 2015 Philippe Proulx <pproulx@efficios.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file objects.h
+ * @brief Basic object system
+ *
+ * This is a basic object system API. The following functions allow you
+ * to create, modify, and destroy:
+ *
+ *   - \link bt_object_null null objects\endlink
+ *   - \link bt_object_bool_create() boolean objects\endlink
+ *   - \link bt_object_integer_create() integer objects\endlink
+ *   - \link bt_object_float_create() floating point number
+ *     objects\endlink
+ *   - \link bt_object_string_create() string objects\endlink
+ *   - \link bt_object_array_create() array objects\endlink,
+ *     containing zero or more objects
+ *   - \link bt_object_map_create() map objects\endlink, mapping
+ *     string keys to objects
+ *
+ * All the object types above, except for null objects (which always
+ * point to the same \link bt_object_null singleton\endlink), have a
+ * reference count property. Once an object is created, its reference
+ * count is set to 1. When \link bt_object_array_append() appending an
+ * object to an array object\endlink, or \link bt_object_map_insert()
+ * inserting an object into a map object\endlink, its reference count
+ * is incremented, as well as when getting an object back from those
+ * structures. The bt_object_get() and bt_object_put() functions exist
+ * to deal with reference counting. Once you are done with an object,
+ * pass it to bt_object_put().
+ *
+ * A common action with objects is to create or get one, do something
+ * with it, and then put it. To avoid putting it a second time later
+ * (if an error occurs, for example), the variable is often reset to
+ * \c NULL after putting the object it points to. Since this is so
+ * common, you can use the BT_OBJECT_PUT() macro, which does just that:
+ *
+ * \code{.c}
+ *     struct bt_object *int_obj = bt_object_integer_create_init(34);
+ *
+ *     if (!int_obj) {
+ *         goto error;
+ *     }
+ *
+ *     // stuff, which could jump to error
+ *
+ *     BT_OBJECT_PUT(int_obj);
+ *
+ *     // stuff, which could jump to error
+ *
+ *     return 0;
+ *
+ * error:
+ *     // safe, even if int_obj is NULL
+ *     BT_OBJECT_PUT(int_obj);
+ * \endcode
+ *
+ * Another common manipulation is to move the ownership of an object
+ * from one variable to another: since the reference count is not
+ * incremented, and since, to avoid errors, two variables should not
+ * point to same object without each of them having their own reference,
+ * it is best practice to set the original variable to \c NULL. This
+ * too can be accomplished in a single step using the BT_OBJECT_MOVE()
+ * macro:
+ *
+ * \code{.c}
+ *     struct bt_object *int_obj2 = NULL;
+ *     struct bt_object *int_obj = bt_object_integer_create_init(-23);
+ *
+ *     if (!int_obj) {
+ *         goto error;
+ *     }
+ *
+ *     // stuff, which could jump to error
+ *
+ *     BT_OBJECT_MOVE(int_obj2, int_obj);
+ *
+ *     // stuff, which could jump to error
+ *
+ *     return 0;
+ *
+ * error:
+ *     // safe, since only one of int_obj/int_obj2 (or none)
+ *     // points to the object
+ *     BT_OBJECT_PUT(int_obj);
+ *     BT_OBJECT_PUT(int_obj2);
+ * \endcode
+ *
+ * You can create a deep copy of any object using the bt_object_copy()
+ * function. You can compare two given objects using
+ * bt_object_compare().
+ *
+ * @author	Philippe Proulx <pproulx@efficios.com>
+ * @bug		No known bugs
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Object type.
+ */
+enum bt_object_type {
+	/** Unknown object, used as an error code. */
+	BT_OBJECT_TYPE_UNKNOWN =	-1,
+
+	/** Null object. */
+	BT_OBJECT_TYPE_NULL =		0,
+
+	/** Boolean object (holds \c true or \c false). */
+	BT_OBJECT_TYPE_BOOL =		1,
+
+	/** Integer (holds a signed 64-bit integer value). */
+	BT_OBJECT_TYPE_INTEGER =	2,
+
+	/**
+	 * Floating point number object (holds a \c double value).
+	 */
+	BT_OBJECT_TYPE_FLOAT =		3,
+
+	/** String object. */
+	BT_OBJECT_TYPE_STRING =		4,
+
+	/** Array object. */
+	BT_OBJECT_TYPE_ARRAY =		5,
+
+	/** Map object. */
+	BT_OBJECT_TYPE_MAP =		6,
+};
+
+/**
+ * Object.
+ */
+struct bt_object;
+
+/**
+ * The null object singleton.
+ *
+ * Use this everytime you need a null objet. The null objet singleton
+ * has no reference count; there's only one. You may compare any object
+ * to the null singleton to find out if it's a null object, or otherwise
+ * use bt_object_is_null().
+ *
+ * Functions of this API return this when the object is actually a
+ * null object (of type \link bt_object_type::BT_OBJECT_TYPE_NULL
+ * <code>BT_OBJECT_TYPE_NULL</code>\endlink), whereas \c NULL means an error
+ * of some sort.
+ */
+extern struct bt_object *bt_object_null;
+
+/**
+ * User function type for bt_object_map_foreach().
+ *
+ * \p object is a \i weak reference; you must pass it to
+ * bt_object_get() to get your own reference.
+ *
+ * Return \c true to continue the loop, or \c false to break it.
+ *
+ * @param key		Key of map entry
+ * @param object	Object of map entry (weak reference)
+ * @param data		User data
+ * @returns		\c true to continue the loop
+ */
+typedef bool (* bt_object_map_foreach_cb)(const char *key,
+	struct bt_object *object, void *data);
+
+/**
+ * Puts the object \p _object (calls bt_object_put() on it), and resets
+ * the variable to \c NULL.
+ *
+ * This is something that is often done when putting and object;
+ * resetting the variable to \c NULL makes sure it cannot be put a
+ * second time later.
+ *
+ * @param _object	Object to put
+ *
+ * @see BT_OBJECT_MOVE() (moves an object from one variable to the other
+ * 			 without putting it)
+ */
+#define BT_OBJECT_PUT(_object)				\
+	do {						\
+		bt_object_put(_object);			\
+		(_object) = NULL;			\
+	} while (0)
+
+/**
+ * Moves the object referenced by the variable \p _src_object to the
+ * \p _dst_object variable, then resets \p _src_object to \c NULL.
+ *
+ * The object's reference count is <b>not changed</b>. Resetting
+ * \p _src_object to \c NULL ensures the object will not be put
+ * twice later; its ownership is indeed \i moved from the source
+ * variable to the destination variable.
+ *
+ * @param _src_object	Source object variable
+ * @param _dst_object	Destination object variable
+ */
+#define BT_OBJECT_MOVE(_dst_object, _src_object)	\
+	do {						\
+		(_dst_object) = (_src_object);		\
+		(_src_object) = NULL;			\
+	} while (0)
+
+/**
+ * Increments the reference count of \p object.
+ *
+ * @param object	Object of which to increment the reference count
+ */
+extern void bt_object_get(struct bt_object *object);
+
+/**
+ * Decrements the reference count of \p object, destroying it when this
+ * count reaches 0.
+ *
+ * @param object	Object of which to decrement the reference count
+ *
+ * @see BT_OBJECT_PUT() (puts an object and resets the variable to
+ * 			\c NULL)
+ */
+extern void bt_object_put(struct bt_object *object);
+
+/**
+ * Returns the type of \p object.
+ *
+ * @param object	Object of which to get the type
+ * @returns		Object's type, or
+ * 			\link bt_object_type::BT_OBJECT_TYPE_NULL
+ * 			<code>BT_OBJECT_TYPE_UNKNOWN</code>\endlink
+ * 			on error
+ *
+ * @see enum bt_object_type (object types)
+ */
+extern enum bt_object_type bt_object_get_type(const struct bt_object *object);
+
+/**
+ * Checks whether \p object is a null object. The only valid null
+ * object is \ref bt_object_null.
+ *
+ * @param object	Object to check
+ * @returns		\c true if \p object is a null object
+ */
+bool bt_object_is_null(const struct bt_object *object)
+{
+	return bt_object_get_type(object) == BT_OBJECT_TYPE_NULL;
+}
+
+/**
+ * Checks whether \p object is a boolean object.
+ *
+ * @param object	Object to check
+ * @returns		\c true if \p object is a boolean object
+ */
+bool bt_object_is_bool(const struct bt_object *object)
+{
+	return bt_object_get_type(object) == BT_OBJECT_TYPE_BOOL;
+}
+
+/**
+ * Checks whether \p object is an integer object.
+ *
+ * @param object	Object to check
+ * @returns		\c true if \p object is an integer object
+ */
+bool bt_object_is_integer(const struct bt_object *object)
+{
+	return bt_object_get_type(object) == BT_OBJECT_TYPE_INTEGER;
+}
+
+/**
+ * Checks whether \p object is a floating point number object.
+ *
+ * @param object	Object to check
+ * @returns		\c true if \p object is a floating point number object
+ */
+bool bt_object_is_float(const struct bt_object *object)
+{
+	return bt_object_get_type(object) == BT_OBJECT_TYPE_FLOAT;
+}
+
+/**
+ * Checks whether \p object is a string object.
+ *
+ * @param object	Object to check
+ * @returns		\c true if \p object is a string object
+ */
+bool bt_object_is_string(const struct bt_object *object)
+{
+	return bt_object_get_type(object) == BT_OBJECT_TYPE_STRING;
+}
+
+/**
+ * Checks whether \p object is an array object.
+ *
+ * @param object	Object to check
+ * @returns		\c true if \p object is an array object
+ */
+bool bt_object_is_array(const struct bt_object *object)
+{
+	return bt_object_get_type(object) == BT_OBJECT_TYPE_ARRAY;
+}
+
+/**
+ * Checks whether \p object is a map object.
+ *
+ * @param object	Object to check
+ * @returns		\c true if \p object is a map object
+ */
+bool bt_object_is_map(const struct bt_object *object)
+{
+	return bt_object_get_type(object) == BT_OBJECT_TYPE_MAP;
+}
+
+/**
+ * Creates a boolean object. The created boolean object's initial value
+ * is \c false.
+ *
+ * The created object's reference count is set to 1.
+ *
+ * @returns	Created object on success, or \c NULL on error
+ */
+extern struct bt_object *bt_object_bool_create(void);
+
+/**
+ * Creates a boolean object with its initial value set to \p val.
+ *
+ * The created object's reference count is set to 1.
+ *
+ * @param val	Initial value
+ * @returns	Created object on success, or \c NULL on error
+ */
+extern struct bt_object *bt_object_bool_create_init(bool val);
+
+/**
+ * Creates an integer object. The created integer object's initial value
+ * is 0.
+ *
+ * The created object's reference count is set to 1.
+ *
+ * @returns	Created object on success, or \c NULL on error
+ */
+extern struct bt_object *bt_object_integer_create(void);
+
+/**
+ * Creates an integer object with its initial value set to \p val.
+ *
+ * The created object's reference count is set to 1.
+ *
+ * @param val	Initial value
+ * @returns	Created object on success, or \c NULL on error
+ */
+extern struct bt_object *bt_object_integer_create_init(int64_t val);
+
+/**
+ * Creates a floating point number object. The created floating point
+ * number object's initial value is 0.
+ *
+ * The created object's reference count is set to 1.
+ *
+ * @returns	Created object on success, or \c NULL on error
+ */
+extern struct bt_object *bt_object_float_create(void);
+
+/**
+ * Creates a floating point number object with its initial value set
+ * to \p val.
+ *
+ * The created object's reference count is set to 1.
+ *
+ * @param val	Initial value
+ * @returns	Created object on success, or \c NULL on error
+ */
+extern struct bt_object *bt_object_float_create_init(double val);
+
+/**
+ * Creates a string object. The string object is initially empty.
+ *
+ * The created object's reference count is set to 1.
+ *
+ * @returns	Created object on success, or \c NULL on error
+ */
+extern struct bt_object *bt_object_string_create(void);
+
+/**
+ * Creates a string object with its initial value set to \p val.
+ *
+ * \p val is copied.
+ *
+ * The created object's reference count is set to 1.
+ *
+ * @param val	Initial value (will be copied)
+ * @returns	Created object on success, or \c NULL on error
+ */
+extern struct bt_object *bt_object_string_create_init(const char *val);
+
+/**
+ * Creates an empty array object.
+ *
+ * The created object's reference count is set to 1.
+ *
+ * @returns	Created object on success, or \c NULL on error
+ */
+extern struct bt_object *bt_object_array_create(void);
+
+/**
+ * Creates an empty map object.
+ *
+ * The created object's reference count is set to 1.
+ *
+ * @returns	Created object on success, or \c NULL on error
+ */
+extern struct bt_object *bt_object_map_create(void);
+
+/**
+ * Gets the boolean value of the boolean objet \p bool_obj.
+ *
+ * @param bool_obj	Boolean object
+ * @param val		Returned boolean value
+ * @returns		0 on success, negative value on error
+ */
+extern int bt_object_bool_get(const struct bt_object *bool_obj, bool *val);
+
+/**
+ * Sets the boolean value of the boolean object \p bool_obj to \p val.
+ *
+ * @param bool_obj	Boolean object
+ * @param val		New boolean value
+ * @returns		0 on success, negative value on error
+ */
+extern int bt_object_bool_set(struct bt_object *bool_obj, bool val);
+
+/**
+ * Gets the integer value of the integer objet \p integer_obj.
+ *
+ * @param integer_obj	Integer object
+ * @param val		Returned integer value
+ * @returns		0 on success, negative value on error
+ */
+extern int bt_object_integer_get(const struct bt_object *integer_obj,
+	int64_t *val);
+
+/**
+ * Sets the integer value of the integer object \p integer_obj to
+ * \p val.
+ *
+ * @param integer_obj	Integer object
+ * @param val		New integer value
+ * @returns		0 on success, negative value on error
+ */
+extern int bt_object_integer_set(struct bt_object *integer_obj, int64_t val);
+
+/**
+ * Gets the floating point number value of the floating point number
+ * objet \p float_obj.
+ *
+ * @param float_obj	Floating point number object
+ * @param val		Returned floating point number value
+ * @returns		0 on success, negative value on error
+ */
+extern int bt_object_float_get(const struct bt_object *float_obj, double *val);
+
+/**
+ * Sets the floating point number value of the floating point number
+ * object \p float_obj to \p val.
+ *
+ * @param float_obj	Floating point number object
+ * @param val		New floating point number value
+ * @returns		0 on success, negative value on error
+ */
+extern int bt_object_float_set(struct bt_object *float_obj, double val);
+
+/**
+ * Gets the string value of the string objet \p string_obj. The
+ * returned string is valid as long as this object exists and is not
+ * modified.
+ *
+ * @param string_obj	String object
+ * @returns		String value, or \c NULL on error
+ */
+extern const char *bt_object_string_get(const struct bt_object *string_obj);
+
+/**
+ * Sets the string value of the string object \p string_obj to
+ * \p val.
+ *
+ * \p val is copied.
+ *
+ * @param string_obj	String object
+ * @param val		New string value (copied)
+ * @returns		0 on success, negative value on error
+ */
+extern int bt_object_string_set(struct bt_object *string_obj, const char *val);
+
+/**
+ * Gets the size of the array object \p array_obj, that is, the number
+ * of elements contained in \p array_obj.
+ *
+ * @param array_obj	Array object
+ * @returns		Array size, or a negative value on error
+ */
+extern int bt_object_array_size(const struct bt_object *array_obj);
+
+/**
+ * Returns \c true if the array object \p array_obj.
+ *
+ * @param array_obj	Array object
+ * @returns		\c true if \p array_obj is empty
+ */
+extern bool bt_object_array_is_empty(const struct bt_object *array_obj);
+
+/**
+ * Gets the element object of the array object \p array_obj at the
+ * index \p index.
+ *
+ * The returned object's reference count is incremented, unless it's
+ * a null object.
+ *
+ * @param array_obj	Array object
+ * @param index		Index of element to get
+ * @returns		Element object at index \p index on success,
+ * 			or \c NULL on error
+ */
+extern struct bt_object *bt_object_array_get(const struct bt_object *array_obj,
+	size_t index);
+
+/**
+ * Appends the element object \p element_obj to the array object
+ * \p array_obj.
+ *
+ * The appended object's reference count is incremented, unless it's
+ * a null object.
+ *
+ * @param array_obj	Array object
+ * @param element_obj	Element object to append
+ * @returns		0 on success, or a negative value on error
+ */
+extern int bt_object_array_append(struct bt_object *array_obj,
+	struct bt_object *element_obj);
+
+/**
+ * Appends the boolean value \p val to the array object \p array_obj.
+ * This is a convenience function which creates the underlying boolean
+ * object before appending it.
+ *
+ * The created boolean object's reference count is set to 1.
+ *
+ * @param array_obj	Array object
+ * @param val		Boolean value to append
+ * @returns		0 on success, or a negative value on error
+ */
+extern int bt_object_array_append_bool(struct bt_object *array_obj, bool val);
+
+/**
+ * Appends the integer value \p val to the array object \p array_obj.
+ * This is a convenience function which creates the underlying integer
+ * object before appending it.
+ *
+ * The created integer object's reference count is set to 1.
+ *
+ * @param array_obj	Array object
+ * @param val		Integer value to append
+ * @returns		0 on success, or a negative value on error
+ */
+extern int bt_object_array_append_integer(struct bt_object *array_obj,
+	int64_t val);
+
+/**
+ * Appends the floating point number value \p val to the array object
+ * \p array_obj. This is a convenience function which creates the
+ * underlying floating point number object before appending it.
+ *
+ * The created floating point number object's reference count is
+ * set to 1.
+ *
+ * @param array_obj	Array object
+ * @param val		Floating point number value to append
+ * @returns		0 on success, or a negative value on error
+ */
+extern int bt_object_array_append_float(struct bt_object *array_obj,
+	double val);
+
+/**
+ * Appends the string value \p val to the array object \p array_obj.
+ * This is a convenience function which creates the underlying string
+ * object before appending it.
+ *
+ * \p val is copied.
+ *
+ * The created string object's reference count is set to 1.
+ *
+ * @param array_obj	Array object
+ * @param val		String value to append (copied)
+ * @returns		0 on success, or a negative value on error
+ */
+extern int bt_object_array_append_string(struct bt_object *array_obj,
+	const char *val);
+
+/**
+ * Appends an empty array object to the array object \p array_obj.
+ * This is a convenience function which creates the underlying array
+ * object before appending it.
+ *
+ * The created array object's reference count is set to 1.
+ *
+ * @param array_obj	Array object
+ * @returns		0 on success, or a negative value on error
+ */
+extern int bt_object_array_append_array(struct bt_object *array_obj);
+
+/**
+ * Appends an empty map object to the array object \p array_obj. This
+ * is a convenience function which creates the underlying map object
+ * before appending it.
+ *
+ * The created map object's reference count is set to 1.
+ *
+ * @param array_obj	Array object
+ * @returns		0 on success, or a negative value on error
+ */
+extern int bt_object_array_append_map(struct bt_object *array_obj);
+
+/**
+ * Gets the size of a map object, that is, the number of elements
+ * contained in a map object.
+ *
+ * @param map_obj	Map object
+ * @returns		Map size, or a negative value on error
+ */
+extern int bt_object_map_size(const struct bt_object *map_obj);
+
+/**
+ * Returns \c true if the map object \p map_obj.
+ *
+ * @param map_obj	Map object
+ * @returns		\c true if \p map_obj is empty
+ */
+extern bool bt_object_map_is_empty(const struct bt_object *map_obj);
+
+/**
+ * Gets the element object associated with the key \p key within the
+ * map object \p map_obj.
+ *
+ * The returned object's reference count is incremented, unless it's
+ * a null object.
+ *
+ * @param map_obj	Map object
+ * @param key		Key of the element to get
+ * @returns		Element object associated with the key \p key
+ * 			on success, or \c NULL on error
+ */
+extern struct bt_object *bt_object_map_get(const struct bt_object *map_obj,
+	const char *key);
+
+/**
+ * Calls a provided user function \p cb for each element of the map
+ * object \p map_obj.
+ *
+ * The object passed to the user function is a <b>weak reference</b>:
+ * you must call bt_object_get() on it to obtain your own reference.
+ *
+ * The key passed to the user function is only valid in the scope of
+ * this user function.
+ *
+ * The user function must return \c true to continue the loop, or
+ * \c false to break it.
+ *
+ * @param map_obj	Map object
+ * @param cb		User function to call back
+ * @param data		User data passed to the user function
+ * @returns		0 on success, or a negative value on error
+ *			(the user function breaking the loop is \b not
+ *			considered an error here)
+ */
+extern int bt_object_map_foreach(const struct bt_object *map_obj,
+	bt_object_map_foreach_cb cb, void *data);
+
+/**
+ * Returns whether or not the map object \p map_obj contains the
+ * key \p key.
+ *
+ * @param map_obj	Map object
+ * @param key		Key to check
+ * @returns		\c true if \p map_obj contains the key \p key,
+ *			or \c false if it doesn't have \p key or
+ *			on error
+ */
+extern bool bt_object_map_has_key(const struct bt_object *map_obj,
+	const char *key);
+
+/**
+ * Inserts the element object \p element_obj associated with the key
+ * \p key into the map object \p map_obj. If \p key exists in
+ * \p map_obj, the associated element object is first put, and then
+ * replaced by \p element_obj.
+ *
+ * \p key is copied.
+ *
+ * The inserted object's reference count is incremented, unless it's
+ * a null object.
+ *
+ * @param map_obj	Map object
+ * @param key		Key (copied) of object to insert
+ * @param element_obj	Element object to insert, associated with the
+ * 			key \p key
+ * @returns		0 on success, or a negative value on error
+ */
+extern int bt_object_map_insert(struct bt_object *map_obj,
+	const char *key, struct bt_object *element_obj);
+
+/**
+ * Inserts the boolean value \p val associated with the key \p key into
+ * the map object \p map_obj. This is a convenience function which
+ * creates the underlying boolean object before inserting it.
+ *
+ * \p key is copied.
+ *
+ * The created boolean object's reference count is set to 1.
+ *
+ * @param map_obj	Map object
+ * @param key		Key (copied) of boolean value to insert
+ * @param val		Boolean value to insert, associated with the
+ * 			key \p key
+ * @returns		0 on success, or a negative value on error
+ */
+extern int bt_object_map_insert_bool(struct bt_object *map_obj,
+	const char *key, bool val);
+
+/**
+ * Inserts the integer value \p val associated with the key \p key into
+ * the map object \p map_obj. This is a convenience function which
+ * creates the underlying integer object before inserting it.
+ *
+ * \p key is copied.
+ *
+ * The created integer object's reference count is set to 1.
+ *
+ * @param map_obj	Map object
+ * @param key		Key (copied) of integer value to insert
+ * @param val		Integer value to insert, associated with the
+ * 			key \p key
+ * @returns		0 on success, or a negative value on error
+ */
+extern int bt_object_map_insert_integer(struct bt_object *map_obj,
+	const char *key, int64_t val);
+
+/**
+ * Inserts the floating point number value \p val associated with the
+ * key \p key into the map object \p map_obj. This is a convenience
+ * function which creates the underlying floating point number object
+ * before inserting it.
+ *
+ * \p key is copied.
+ *
+ * The created floating point number object's reference count is
+ * set to 1.
+ *
+ * @param map_obj	Map object
+ * @param key		Key (copied) of floating point number value to
+ * 			insert
+ * @param val		Floating point number value to insert,
+ * 			associated with the key \p key
+ * @returns		0 on success, or a negative value on error
+ */
+extern int bt_object_map_insert_float(struct bt_object *map_obj,
+	const char *key, double val);
+
+/**
+ * Inserts the string value \p val associated with the key \p key into
+ * the map object \p map_obj. This is a convenience function which
+ * creates the underlying string object before inserting it.
+ *
+ * \p val and \p key are copied.
+ *
+ * The created string object's reference count is set to 1.
+ *
+ * @param map_obj	Map object
+ * @param key		Key (copied) of string value to insert
+ * @param val		String value to insert, associated with the
+ * 			key \p key
+ * @returns		0 on success, or a negative value on error
+ */
+extern int bt_object_map_insert_string(struct bt_object *map_obj,
+	const char *key, const char *val);
+
+/**
+ * Inserts an empty array object associated with the key \p key into
+ * the map object \p map_obj. This is a convenience function which
+ * creates the underlying array object before inserting it.
+ *
+ * \p key is copied.
+ *
+ * The created array object's reference count is set to 1.
+ *
+ * @param map_obj	Map object
+ * @param key		Key (copied) of empty array to insert
+ * @returns		0 on success, or a negative value on error
+ */
+extern int bt_object_map_insert_array(struct bt_object *map_obj,
+	const char *key);
+
+/**
+ * Inserts an empty map object associated with the key \p key into
+ * the map object \p map_obj. This is a convenience function which
+ * creates the underlying map object before inserting it.
+ *
+ * \p key is copied.
+ *
+ * The created map object's reference count is set to 1.
+ *
+ * @param map_obj	Map object
+ * @param key		Key (copied) of empty map to insert
+ * @returns		0 on success, or a negative value on error
+ */
+extern int bt_object_map_insert_map(struct bt_object *map_obj,
+	const char *key);
+
+/**
+ * Creates a deep copy of the object \p object.
+ *
+ * The created object's reference count is set to 1, unless
+ * \p object is a null object.
+ *
+ * @param object	Object to copy
+ * @returns		Deep copy of \p object on success, or \c NULL
+ * 			on error
+ */
+extern struct bt_object *bt_object_copy(const struct bt_object *object);
+
+/**
+ * Compares the objects \p object_a and \p object_b and returns \c true
+ * if they have the same content.
+ *
+ * @param object_a	Object A
+ * @param object_B	Object B
+ * @returns		\c true if \p object_a and \p object_b have the
+ * 			same content, or \c false if they differ or on
+ * 			error
+ */
+extern bool bt_object_compare(const struct bt_object *object_a,
+	const struct bt_object *object_b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _BABELTRACE_OBJECTS_H */

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -9,7 +9,8 @@ libbabeltrace_la_SOURCES = babeltrace.c \
 			   context.c \
 			   trace-handle.c \
 			   trace-collection.c \
-			   registry.c
+			   registry.c \
+			   objects.c
 
 libbabeltrace_la_LDFLAGS = -version-info $(BABELTRACE_LIBRARY_VERSION)
 

--- a/lib/objects.c
+++ b/lib/objects.c
@@ -1,0 +1,1092 @@
+/*
+ * objects.c: basic object system
+ *
+ * Babeltrace Library
+ *
+ * Copyright (c) 2015 EfficiOS Inc. and Linux Foundation
+ * Copyright (c) 2015 Philippe Proulx <pproulx@efficios.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <string.h>
+#include <babeltrace/ctf-writer/ref-internal.h>
+#include <babeltrace/compiler.h>
+#include <glib.h>
+#include <babeltrace/objects.h>
+
+#define BT_OBJECT_FROM_CONCRETE(_concrete) ((struct bt_object *) (_concrete))
+#define BT_OBJECT_TO_BOOL(_base) ((struct bt_object_bool *) (_base))
+#define BT_OBJECT_TO_INTEGER(_base) ((struct bt_object_integer *) (_base))
+#define BT_OBJECT_TO_FLOAT(_base) ((struct bt_object_float *) (_base))
+#define BT_OBJECT_TO_STRING(_base) ((struct bt_object_string *) (_base))
+#define BT_OBJECT_TO_ARRAY(_base) ((struct bt_object_array *) (_base))
+#define BT_OBJECT_TO_MAP(_base) ((struct bt_object_map *) (_base))
+
+struct bt_object {
+	enum bt_object_type type;
+	struct bt_ctf_ref ref_count;
+};
+
+static
+struct bt_object bt_object_null_instance = {
+	.type = BT_OBJECT_TYPE_NULL,
+};
+
+struct bt_object *bt_object_null = &bt_object_null_instance;
+
+struct bt_object_bool {
+	struct bt_object base;
+	bool value;
+};
+
+struct bt_object_integer {
+	struct bt_object base;
+	int64_t value;
+};
+
+struct bt_object_float {
+	struct bt_object base;
+	double value;
+};
+
+struct bt_object_string {
+	struct bt_object base;
+	GString *gstr;
+};
+
+struct bt_object_array {
+	struct bt_object base;
+	GArray *garray;
+};
+
+struct bt_object_map {
+	struct bt_object base;
+	GHashTable *ght;
+};
+
+static
+void bt_object_string_destroy(struct bt_object *object)
+{
+	struct bt_object_string *string_obj = BT_OBJECT_TO_STRING(object);
+
+	g_string_free(string_obj->gstr, TRUE);
+}
+
+static
+void bt_object_array_destroy(struct bt_object *object)
+{
+	int x;
+	struct bt_object_array *array_obj = BT_OBJECT_TO_ARRAY(object);
+
+	for (x = 0; x < array_obj->garray->len; ++x) {
+		struct bt_object *el_obj;
+
+		el_obj = g_array_index(array_obj->garray,
+			struct bt_object *, x);
+		bt_object_put(el_obj);
+	}
+
+	g_array_free(array_obj->garray, TRUE);
+}
+
+static
+void bt_object_map_destroy(struct bt_object *object)
+{
+	struct bt_object_map *map = BT_OBJECT_TO_MAP(object);
+
+	/*
+	 * Hash table's registered value destructor will take care of
+	 * putting each contained object. Keys are GQuarks and cannot
+	 * be destroyed anyway.
+	 */
+	g_hash_table_destroy(map->ght);
+}
+
+static
+void (* const destroy_funcs[])(struct bt_object *) = {
+	[BT_OBJECT_TYPE_NULL] =		NULL,
+	[BT_OBJECT_TYPE_BOOL] =		NULL,
+	[BT_OBJECT_TYPE_INTEGER] =	NULL,
+	[BT_OBJECT_TYPE_FLOAT] =	NULL,
+	[BT_OBJECT_TYPE_STRING] =	bt_object_string_destroy,
+	[BT_OBJECT_TYPE_ARRAY] =	bt_object_array_destroy,
+	[BT_OBJECT_TYPE_MAP] =		bt_object_map_destroy,
+};
+
+static
+struct bt_object *bt_object_null_copy(const struct bt_object *null_obj)
+{
+	return bt_object_null;
+}
+
+static
+struct bt_object *bt_object_bool_copy(const struct bt_object *bool_obj)
+{
+	return bt_object_bool_create_init(BT_OBJECT_TO_BOOL(bool_obj)->value);
+}
+
+static
+struct bt_object *bt_object_integer_copy(const struct bt_object *integer_obj)
+{
+	return bt_object_integer_create_init(
+		BT_OBJECT_TO_INTEGER(integer_obj)->value);
+}
+
+static
+struct bt_object *bt_object_float_copy(const struct bt_object *float_obj)
+{
+	return bt_object_float_create_init(
+		BT_OBJECT_TO_FLOAT(float_obj)->value);
+}
+
+static
+struct bt_object *bt_object_string_copy(const struct bt_object *string_obj)
+{
+	return bt_object_string_create_init(
+		BT_OBJECT_TO_STRING(string_obj)->gstr->str);
+}
+
+static
+struct bt_object *bt_object_array_copy(const struct bt_object *array_obj)
+{
+	int x;
+	int ret;
+	struct bt_object *copy_obj;
+	struct bt_object_array *typed_array_obj;
+
+	typed_array_obj = BT_OBJECT_TO_ARRAY(array_obj);
+	copy_obj = bt_object_array_create();
+
+	if (!copy_obj) {
+		goto end;
+	}
+
+	for (x = 0; x < typed_array_obj->garray->len; ++x) {
+		struct bt_object *element_obj_copy;
+		struct bt_object *element_obj =
+			bt_object_array_get(array_obj, x);
+
+		if (!element_obj) {
+			BT_OBJECT_PUT(copy_obj);
+			goto end;
+		}
+
+		element_obj_copy = bt_object_copy(element_obj);
+		BT_OBJECT_PUT(element_obj);
+
+		if (!element_obj_copy) {
+			BT_OBJECT_PUT(copy_obj);
+			goto end;
+		}
+
+		ret = bt_object_array_append(copy_obj, element_obj_copy);
+		BT_OBJECT_PUT(element_obj_copy);
+
+		if (ret) {
+			BT_OBJECT_PUT(copy_obj);
+			goto end;
+		}
+	}
+
+end:
+	return copy_obj;
+}
+
+static
+struct bt_object *bt_object_map_copy(const struct bt_object *map_obj)
+{
+	int ret;
+	GHashTableIter iter;
+	gpointer key, element_obj;
+	struct bt_object *copy_obj;
+	struct bt_object *element_obj_copy;
+	struct bt_object_map *typed_map_obj;
+
+	typed_map_obj = BT_OBJECT_TO_MAP(map_obj);
+	copy_obj = bt_object_map_create();
+
+	if (!copy_obj) {
+		goto end;
+	}
+
+	g_hash_table_iter_init(&iter, typed_map_obj->ght);
+
+	while (g_hash_table_iter_next(&iter, &key, &element_obj)) {
+		const char *key_str = g_quark_to_string((unsigned long) key);
+
+		element_obj_copy = bt_object_copy(element_obj);
+
+		if (!element_obj_copy) {
+			BT_OBJECT_PUT(copy_obj);
+			goto end;
+		}
+
+		ret = bt_object_map_insert(copy_obj, key_str, element_obj_copy);
+		BT_OBJECT_PUT(element_obj_copy);
+
+		if (ret) {
+			BT_OBJECT_PUT(copy_obj);
+			goto end;
+		}
+	}
+
+end:
+	return copy_obj;
+}
+
+static
+struct bt_object *(* const copy_funcs[])(const struct bt_object *) = {
+	[BT_OBJECT_TYPE_NULL] =		bt_object_null_copy,
+	[BT_OBJECT_TYPE_BOOL] =		bt_object_bool_copy,
+	[BT_OBJECT_TYPE_INTEGER] =	bt_object_integer_copy,
+	[BT_OBJECT_TYPE_FLOAT] =	bt_object_float_copy,
+	[BT_OBJECT_TYPE_STRING] =	bt_object_string_copy,
+	[BT_OBJECT_TYPE_ARRAY] =	bt_object_array_copy,
+	[BT_OBJECT_TYPE_MAP] =		bt_object_map_copy,
+};
+
+static
+bool bt_object_null_compare(const struct bt_object *object_a,
+		const struct bt_object *object_b)
+{
+	/*
+	 * Always true since bt_object_compare() already checks if both
+	 * object_a and object_b have the same type, and in the case of
+	 * null objects, they're always the same if it is so.
+	 */
+	return true;
+}
+
+static
+bool bt_object_bool_compare(const struct bt_object *object_a,
+		const struct bt_object *object_b)
+{
+	return BT_OBJECT_TO_BOOL(object_a)->value ==
+		BT_OBJECT_TO_BOOL(object_b)->value;
+}
+
+static
+bool bt_object_integer_compare(const struct bt_object *object_a,
+		const struct bt_object *object_b)
+{
+	return BT_OBJECT_TO_INTEGER(object_a)->value ==
+		BT_OBJECT_TO_INTEGER(object_b)->value;
+}
+
+static
+bool bt_object_float_compare(const struct bt_object *object_a,
+		const struct bt_object *object_b)
+{
+	return BT_OBJECT_TO_FLOAT(object_a)->value ==
+		BT_OBJECT_TO_FLOAT(object_b)->value;
+}
+
+static
+bool bt_object_string_compare(const struct bt_object *object_a,
+		const struct bt_object *object_b)
+{
+	return !strcmp(BT_OBJECT_TO_STRING(object_a)->gstr->str,
+		BT_OBJECT_TO_STRING(object_b)->gstr->str);
+}
+
+static
+bool bt_object_array_compare(const struct bt_object *object_a,
+		const struct bt_object *object_b)
+{
+	int x;
+	bool ret = true;
+	const struct bt_object_array *array_obj_a =
+		BT_OBJECT_TO_ARRAY(object_a);
+
+	if (bt_object_array_size(object_a) != bt_object_array_size(object_b)) {
+		ret = false;
+		goto end;
+	}
+
+	for (x = 0; x < array_obj_a->garray->len; ++x) {
+		struct bt_object *element_obj_a;
+		struct bt_object *element_obj_b;
+
+		element_obj_a = bt_object_array_get(object_a, x);
+		element_obj_b = bt_object_array_get(object_b, x);
+
+		if (!bt_object_compare(element_obj_a, element_obj_b)) {
+			BT_OBJECT_PUT(element_obj_a);
+			BT_OBJECT_PUT(element_obj_b);
+			ret = false;
+			goto end;
+		}
+
+		BT_OBJECT_PUT(element_obj_a);
+		BT_OBJECT_PUT(element_obj_b);
+	}
+
+end:
+	return ret;
+}
+
+static
+bool bt_object_map_compare(const struct bt_object *object_a,
+		const struct bt_object *object_b)
+{
+	bool ret = true;
+	GHashTableIter iter;
+	gpointer key, element_obj_a;
+	const struct bt_object_map *map_obj_a = BT_OBJECT_TO_MAP(object_a);
+
+	if (bt_object_map_size(object_a) != bt_object_map_size(object_b)) {
+		ret = false;
+		goto end;
+	}
+
+	g_hash_table_iter_init(&iter, map_obj_a->ght);
+
+	while (g_hash_table_iter_next(&iter, &key, &element_obj_a)) {
+		struct bt_object *element_obj_b;
+		const char *key_str = g_quark_to_string((unsigned long) key);
+
+		element_obj_b = bt_object_map_get(object_b, key_str);
+
+		if (!bt_object_compare(element_obj_a, element_obj_b)) {
+			BT_OBJECT_PUT(element_obj_b);
+			ret = false;
+			goto end;
+		}
+
+		BT_OBJECT_PUT(element_obj_b);
+	}
+
+end:
+	return ret;
+}
+
+static
+bool (* const compare_funcs[])(const struct bt_object *,
+		const struct bt_object *) = {
+	[BT_OBJECT_TYPE_NULL] =		bt_object_null_compare,
+	[BT_OBJECT_TYPE_BOOL] =		bt_object_bool_compare,
+	[BT_OBJECT_TYPE_INTEGER] =	bt_object_integer_compare,
+	[BT_OBJECT_TYPE_FLOAT] =	bt_object_float_compare,
+	[BT_OBJECT_TYPE_STRING] =	bt_object_string_compare,
+	[BT_OBJECT_TYPE_ARRAY] =	bt_object_array_compare,
+	[BT_OBJECT_TYPE_MAP] =		bt_object_map_compare,
+};
+
+static
+void bt_object_destroy(struct bt_ctf_ref *ref_count)
+{
+	struct bt_object *object;
+
+	object = container_of(ref_count, struct bt_object, ref_count);
+	assert(object->type != BT_OBJECT_TYPE_UNKNOWN);
+
+	if (bt_object_is_null(object)) {
+		return;
+	}
+
+	if (destroy_funcs[object->type]) {
+		destroy_funcs[object->type](object);
+	}
+
+	g_free(object);
+}
+
+void bt_object_get(struct bt_object *object)
+{
+	if (!object) {
+		goto skip;
+	}
+
+	bt_ctf_ref_get(&object->ref_count);
+
+skip:
+	return;
+}
+
+void bt_object_put(struct bt_object *object)
+{
+	if (!object) {
+		goto skip;
+	}
+
+	bt_ctf_ref_put(&object->ref_count, bt_object_destroy);
+
+skip:
+	return;
+}
+
+enum bt_object_type bt_object_get_type(const struct bt_object *object)
+{
+	if (!object) {
+		return BT_OBJECT_TYPE_UNKNOWN;
+	}
+
+	return object->type;
+}
+
+static
+struct bt_object bt_object_create_base(enum bt_object_type type)
+{
+	struct bt_object base;
+
+	base.type = type;
+	bt_ctf_ref_init(&base.ref_count);
+
+	return base;
+}
+
+struct bt_object *bt_object_bool_create_init(bool val)
+{
+	struct bt_object_bool *bool_obj;
+
+	bool_obj = g_new0(struct bt_object_bool, 1);
+
+	if (!bool_obj) {
+		goto end;
+	}
+
+	bool_obj->base = bt_object_create_base(BT_OBJECT_TYPE_BOOL);
+	bool_obj->value = val;
+
+end:
+	return BT_OBJECT_FROM_CONCRETE(bool_obj);
+}
+
+struct bt_object *bt_object_bool_create(void)
+{
+	return bt_object_bool_create_init(false);
+}
+
+struct bt_object *bt_object_integer_create_init(int64_t val)
+{
+	struct bt_object_integer *integer_obj;
+
+	integer_obj = g_new0(struct bt_object_integer, 1);
+
+	if (!integer_obj) {
+		goto end;
+	}
+
+	integer_obj->base = bt_object_create_base(BT_OBJECT_TYPE_INTEGER);
+	integer_obj->value = val;
+
+end:
+	return BT_OBJECT_FROM_CONCRETE(integer_obj);
+}
+
+struct bt_object *bt_object_integer_create(void)
+{
+	return bt_object_integer_create_init(0);
+}
+
+struct bt_object *bt_object_float_create_init(double val)
+{
+	struct bt_object_float *float_obj;
+
+	float_obj = g_new0(struct bt_object_float, 1);
+
+	if (!float_obj) {
+		goto end;
+	}
+
+	float_obj->base = bt_object_create_base(BT_OBJECT_TYPE_FLOAT);
+	float_obj->value = val;
+
+end:
+	return BT_OBJECT_FROM_CONCRETE(float_obj);
+}
+
+struct bt_object *bt_object_float_create(void)
+{
+	return bt_object_float_create_init(0.);
+}
+
+struct bt_object *bt_object_string_create_init(const char *val)
+{
+	struct bt_object_string *string_obj = NULL;
+
+	if (!val) {
+		goto end;
+	}
+
+	string_obj = g_new0(struct bt_object_string, 1);
+
+	if (!string_obj) {
+		goto end;
+	}
+
+	string_obj->base = bt_object_create_base(BT_OBJECT_TYPE_STRING);
+	string_obj->gstr = g_string_new(val);
+
+	if (!string_obj->gstr) {
+		g_free(string_obj);
+		string_obj = NULL;
+		goto end;
+	}
+
+end:
+	return BT_OBJECT_FROM_CONCRETE(string_obj);
+}
+
+struct bt_object *bt_object_string_create(void)
+{
+	return bt_object_string_create_init("");
+}
+
+struct bt_object *bt_object_array_create(void)
+{
+	struct bt_object_array *array_obj;
+
+	array_obj = g_new0(struct bt_object_array, 1);
+
+	if (!array_obj) {
+		goto end;
+	}
+
+	array_obj->base = bt_object_create_base(BT_OBJECT_TYPE_ARRAY);
+	array_obj->garray = g_array_new(FALSE, FALSE,
+		sizeof(struct bt_object *));
+
+	if (!array_obj->garray) {
+		g_free(array_obj);
+		array_obj = NULL;
+		goto end;
+	}
+
+end:
+	return BT_OBJECT_FROM_CONCRETE(array_obj);
+}
+
+struct bt_object *bt_object_map_create(void)
+{
+	struct bt_object_map *map_obj;
+
+	map_obj = g_new0(struct bt_object_map, 1);
+
+	if (!map_obj) {
+		goto end;
+	}
+
+	map_obj->base = bt_object_create_base(BT_OBJECT_TYPE_MAP);
+	map_obj->ght = g_hash_table_new_full(g_direct_hash, g_direct_equal,
+		NULL, (GDestroyNotify) bt_object_put);
+
+	if (!map_obj->ght) {
+		g_free(map_obj);
+		map_obj = NULL;
+		goto end;
+	}
+
+end:
+	return BT_OBJECT_FROM_CONCRETE(map_obj);
+}
+
+int bt_object_bool_get(const struct bt_object *bool_obj, bool *val)
+{
+	int ret = 0;
+	struct bt_object_bool *typed_bool_obj = BT_OBJECT_TO_BOOL(bool_obj);
+
+	if (!bool_obj || !bt_object_is_bool(bool_obj)) {
+		ret = -1;
+		goto end;
+	}
+
+	*val = typed_bool_obj->value;
+
+end:
+	return ret;
+}
+
+int bt_object_bool_set(struct bt_object *bool_obj, bool val)
+{
+	int ret = 0;
+	struct bt_object_bool *typed_bool_obj = BT_OBJECT_TO_BOOL(bool_obj);
+
+	if (!bool_obj || !bt_object_is_bool(bool_obj)) {
+		ret = -1;
+		goto end;
+	}
+
+	typed_bool_obj->value = val;
+
+end:
+	return ret;
+}
+
+int bt_object_integer_get(const struct bt_object *integer_obj, int64_t *val)
+{
+	int ret = 0;
+	struct bt_object_integer *typed_integer_obj =
+		BT_OBJECT_TO_INTEGER(integer_obj);
+
+	if (!integer_obj || !bt_object_is_integer(integer_obj)) {
+		ret = -1;
+		goto end;
+	}
+
+	*val = typed_integer_obj->value;
+
+end:
+	return ret;
+}
+
+int bt_object_integer_set(struct bt_object *integer_obj, int64_t val)
+{
+	int ret = 0;
+	struct bt_object_integer *typed_integer_obj =
+		BT_OBJECT_TO_INTEGER(integer_obj);
+
+	if (!integer_obj || !bt_object_is_integer(integer_obj)) {
+		ret = -1;
+		goto end;
+	}
+
+	typed_integer_obj->value = val;
+
+end:
+	return ret;
+}
+
+int bt_object_float_get(const struct bt_object *float_obj, double *val)
+{
+	int ret = 0;
+	struct bt_object_float *typed_float_obj =
+		BT_OBJECT_TO_FLOAT(float_obj);
+
+	if (!float_obj || !bt_object_is_float(float_obj)) {
+		ret = -1;
+		goto end;
+	}
+
+	*val = typed_float_obj->value;
+
+end:
+	return ret;
+}
+
+int bt_object_float_set(struct bt_object *float_obj, double val)
+{
+	int ret = 0;
+	struct bt_object_float *typed_float_obj =
+		BT_OBJECT_TO_FLOAT(float_obj);
+
+	if (!float_obj || !bt_object_is_float(float_obj)) {
+		ret = -1;
+		goto end;
+	}
+
+	typed_float_obj->value = val;
+
+end:
+	return ret;
+}
+
+const char *bt_object_string_get(const struct bt_object *string_obj)
+{
+	const char *ret;
+	struct bt_object_string *typed_string_obj =
+		BT_OBJECT_TO_STRING(string_obj);
+
+	if (!string_obj || !bt_object_is_string(string_obj)) {
+		ret = NULL;
+		goto end;
+	}
+
+	ret = typed_string_obj->gstr->str;
+
+end:
+	return ret;
+}
+
+int bt_object_string_set(struct bt_object *string_obj, const char *val)
+{
+	int ret = 0;
+	struct bt_object_string *typed_string_obj =
+		BT_OBJECT_TO_STRING(string_obj);
+
+	if (!string_obj || !bt_object_is_string(string_obj) || !val) {
+		ret = -1;
+		goto end;
+	}
+
+	g_string_assign(typed_string_obj->gstr, val);
+
+end:
+	return ret;
+}
+
+int bt_object_array_size(const struct bt_object *array_obj)
+{
+	int ret = 0;
+	struct bt_object_array *typed_array_obj =
+		BT_OBJECT_TO_ARRAY(array_obj);
+
+	if (!array_obj || !bt_object_is_array(array_obj)) {
+		ret = -1;
+		goto end;
+	}
+
+	ret = (int) typed_array_obj->garray->len;
+
+end:
+	return ret;
+}
+
+bool bt_object_array_is_empty(const struct bt_object *array_obj)
+{
+	return bt_object_array_size(array_obj) == 0;
+}
+
+struct bt_object *bt_object_array_get(const struct bt_object *array_obj,
+	size_t index)
+{
+	struct bt_object *ret;
+	struct bt_object_array *typed_array_obj =
+		BT_OBJECT_TO_ARRAY(array_obj);
+
+	if (!array_obj || !bt_object_is_array(array_obj) ||
+			index >= typed_array_obj->garray->len) {
+		ret = NULL;
+		goto end;
+	}
+
+	ret = g_array_index(typed_array_obj->garray,
+		struct bt_object *, index);
+	bt_object_get(ret);
+
+end:
+	return ret;
+}
+
+int bt_object_array_append(struct bt_object *array_obj,
+	struct bt_object *element_obj)
+{
+	int ret = 0;
+	struct bt_object_array *typed_array_obj =
+		BT_OBJECT_TO_ARRAY(array_obj);
+
+	if (!array_obj || !bt_object_is_array(array_obj) || !element_obj) {
+		ret = -1;
+		goto end;
+	}
+
+	g_array_append_val(typed_array_obj->garray, element_obj);
+	bt_object_get(element_obj);
+
+end:
+	return ret;
+}
+
+int bt_object_array_append_bool(struct bt_object *array_obj, bool val)
+{
+	int ret;
+	struct bt_object *bool_obj = NULL;
+
+	bool_obj = bt_object_bool_create_init(val);
+	ret = bt_object_array_append(array_obj, bool_obj);
+	bt_object_put(bool_obj);
+
+	return ret;
+}
+
+int bt_object_array_append_integer(struct bt_object *array_obj, int64_t val)
+{
+	int ret;
+	struct bt_object *integer_obj = NULL;
+
+	integer_obj = bt_object_integer_create_init(val);
+	ret = bt_object_array_append(array_obj, integer_obj);
+	bt_object_put(integer_obj);
+
+	return ret;
+}
+
+int bt_object_array_append_float(struct bt_object *array_obj, double val)
+{
+	int ret;
+	struct bt_object *float_obj = NULL;
+
+	float_obj = bt_object_float_create_init(val);
+	ret = bt_object_array_append(array_obj, float_obj);
+	bt_object_put(float_obj);
+
+	return ret;
+}
+
+int bt_object_array_append_string(struct bt_object *array_obj, const char *val)
+{
+	int ret;
+	struct bt_object *string_obj = NULL;
+
+	string_obj = bt_object_string_create_init(val);
+	ret = bt_object_array_append(array_obj, string_obj);
+	bt_object_put(string_obj);
+
+	return ret;
+}
+
+int bt_object_array_append_array(struct bt_object *array_obj)
+{
+	int ret;
+	struct bt_object *empty_array_obj = NULL;
+
+	empty_array_obj = bt_object_array_create();
+	ret = bt_object_array_append(array_obj, empty_array_obj);
+	bt_object_put(empty_array_obj);
+
+	return ret;
+}
+
+int bt_object_array_append_map(struct bt_object *array_obj)
+{
+	int ret;
+	struct bt_object *map_obj = NULL;
+
+	map_obj = bt_object_map_create();
+	ret = bt_object_array_append(array_obj, map_obj);
+	bt_object_put(map_obj);
+
+	return ret;
+}
+
+int bt_object_map_size(const struct bt_object *map_obj)
+{
+	int ret;
+	struct bt_object_map *typed_map_obj = BT_OBJECT_TO_MAP(map_obj);
+
+	if (!map_obj || !bt_object_is_map(map_obj)) {
+		ret = -1;
+		goto end;
+	}
+
+	ret = (int) g_hash_table_size(typed_map_obj->ght);
+
+end:
+	return ret;
+}
+
+bool bt_object_map_is_empty(const struct bt_object *map_obj)
+{
+	return bt_object_map_size(map_obj) == 0;
+}
+
+struct bt_object *bt_object_map_get(const struct bt_object *map_obj,
+	const char *key)
+{
+	GQuark quark;
+	struct bt_object *ret;
+	struct bt_object_map *typed_map_obj = BT_OBJECT_TO_MAP(map_obj);
+
+	if (!map_obj || !bt_object_is_map(map_obj) || !key) {
+		ret = NULL;
+		goto end;
+	}
+
+	quark = g_quark_from_string(key);
+	ret = g_hash_table_lookup(typed_map_obj->ght, GUINT_TO_POINTER(quark));
+
+	if (ret) {
+		bt_object_get(ret);
+	}
+
+end:
+	return ret;
+}
+
+bool bt_object_map_has_key(const struct bt_object *map_obj, const char *key)
+{
+	bool ret;
+	GQuark quark;
+	struct bt_object_map *typed_map_obj = BT_OBJECT_TO_MAP(map_obj);
+
+	if (!map_obj || !bt_object_is_map(map_obj) || !key) {
+		ret = false;
+		goto end;
+	}
+
+	quark = g_quark_from_string(key);
+	ret = g_hash_table_contains(typed_map_obj->ght,
+		GUINT_TO_POINTER(quark));
+
+end:
+	return ret;
+}
+
+int bt_object_map_insert(struct bt_object *map_obj, const char *key,
+	struct bt_object *element_obj)
+{
+	int ret = 0;
+	GQuark quark;
+	struct bt_object_map *typed_map_obj = BT_OBJECT_TO_MAP(map_obj);
+
+	if (!map_obj || !bt_object_is_map(map_obj) || !key || !element_obj) {
+		ret = -1;
+		goto end;
+	}
+
+	quark = g_quark_from_string(key);
+	g_hash_table_insert(typed_map_obj->ght,
+		GUINT_TO_POINTER(quark), element_obj);
+	bt_object_get(element_obj);
+
+end:
+	return ret;
+}
+
+int bt_object_map_insert_bool(struct bt_object *map_obj,
+	const char *key, bool val)
+{
+	int ret;
+	struct bt_object *bool_obj = NULL;
+
+	bool_obj = bt_object_bool_create_init(val);
+	ret = bt_object_map_insert(map_obj, key, bool_obj);
+	bt_object_put(bool_obj);
+
+	return ret;
+}
+
+int bt_object_map_insert_integer(struct bt_object *map_obj,
+	const char *key, int64_t val)
+{
+	int ret;
+	struct bt_object *integer_obj = NULL;
+
+	integer_obj = bt_object_integer_create_init(val);
+	ret = bt_object_map_insert(map_obj, key, integer_obj);
+	bt_object_put(integer_obj);
+
+	return ret;
+}
+
+int bt_object_map_insert_float(struct bt_object *map_obj,
+	const char *key, double val)
+{
+	int ret;
+	struct bt_object *float_obj = NULL;
+
+	float_obj = bt_object_float_create_init(val);
+	ret = bt_object_map_insert(map_obj, key, float_obj);
+	bt_object_put(float_obj);
+
+	return ret;
+}
+
+int bt_object_map_insert_string(struct bt_object *map_obj,
+	const char *key, const char *val)
+{
+	int ret;
+	struct bt_object *string_obj = NULL;
+
+	string_obj = bt_object_string_create_init(val);
+	ret = bt_object_map_insert(map_obj, key, string_obj);
+	bt_object_put(string_obj);
+
+	return ret;
+}
+
+int bt_object_map_insert_array(struct bt_object *map_obj,
+	const char *key)
+{
+	int ret;
+	struct bt_object *array_obj = NULL;
+
+	array_obj = bt_object_array_create();
+	ret = bt_object_map_insert(map_obj, key, array_obj);
+	bt_object_put(array_obj);
+
+	return ret;
+}
+
+int bt_object_map_insert_map(struct bt_object *map_obj,
+	const char *key)
+{
+	int ret;
+	struct bt_object *empty_map_obj = NULL;
+
+	empty_map_obj = bt_object_map_create();
+	ret = bt_object_map_insert(map_obj, key, empty_map_obj);
+	bt_object_put(empty_map_obj);
+
+	return ret;
+}
+
+int bt_object_map_foreach(const struct bt_object *map_obj,
+	bt_object_map_foreach_cb cb, void *data)
+{
+	int ret = 0;
+	gpointer key, element_obj;
+	GHashTableIter iter;
+	struct bt_object_map *typed_map_obj = BT_OBJECT_TO_MAP(map_obj);
+
+	if (!map_obj || !bt_object_is_map(map_obj) || !cb) {
+		ret = -1;
+		goto end;
+	}
+
+	g_hash_table_iter_init(&iter, typed_map_obj->ght);
+
+	while (g_hash_table_iter_next(&iter, &key, &element_obj)) {
+		const char *key_str = g_quark_to_string((unsigned long) key);
+
+		if (!cb(key_str, element_obj, data)) {
+			break;
+		}
+	}
+
+end:
+	return ret;
+}
+
+struct bt_object *bt_object_copy(const struct bt_object *object)
+{
+	struct bt_object *copy_obj = NULL;
+
+	if (!object) {
+		goto end;
+	}
+
+	copy_obj = copy_funcs[object->type](object);
+
+end:
+	return copy_obj;
+}
+
+bool bt_object_compare(const struct bt_object *object_a,
+	const struct bt_object *object_b)
+{
+	bool ret = false;
+
+	if (!object_a || !object_b) {
+		goto end;
+	}
+
+	if (object_a->type != object_b->type) {
+		goto end;
+	}
+
+	ret = compare_funcs[object_a->type](object_a, object_b);
+
+end:
+	return ret;
+}

--- a/tests/lib/Makefile.am
+++ b/tests/lib/Makefile.am
@@ -20,15 +20,20 @@ test_ctf_writer_LDADD = $(LIBTAP) \
 	$(top_builddir)/lib/libbabeltrace.la \
 	$(top_builddir)/formats/ctf/libbabeltrace-ctf.la
 
-noinst_PROGRAMS = test_seek test_bitfield test_ctf_writer
+test_bt_objects_LDADD = $(LIBTAP) \
+	$(top_builddir)/lib/libbabeltrace.la
+
+noinst_PROGRAMS = test_seek test_bitfield test_ctf_writer test_bt_objects
 
 test_seek_SOURCES = test_seek.c
 test_bitfield_SOURCES = test_bitfield.c
 test_ctf_writer_SOURCES = test_ctf_writer.c
+test_bt_objects_SOURCES = test_bt_objects.c
 
 SCRIPT_LIST = test_seek_big_trace \
 	test_seek_empty_packet \
-	test_ctf_writer_complete
+	test_ctf_writer_complete \
+	test_bt_objects
 
 dist_noinst_SCRIPTS = $(SCRIPT_LIST)
 

--- a/tests/lib/test_bt_objects.c
+++ b/tests/lib/test_bt_objects.c
@@ -1,0 +1,977 @@
+/*
+ * test_bt_objects.c
+ *
+ * Babeltrace basic object system tests
+ *
+ * Copyright (c) 2015 EfficiOS Inc. and Linux Foundation
+ * Copyright (c) 2015 Philippe Proulx <pproulx@efficios.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; under version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#define _GNU_SOURCE
+#include <babeltrace/objects.h>
+#include <assert.h>
+#include <string.h>
+#include "tap/tap.h"
+
+static
+void test_null(void)
+{
+	ok(bt_object_null, "bt_object_null is not NULL");
+	ok(bt_object_is_null(bt_object_null),
+		"bt_object_null is a null object");
+	bt_object_get(bt_object_null);
+	pass("getting bt_object_null does not cause a crash");
+	bt_object_put(bt_object_null);
+	pass("putting bt_object_null does not cause a crash");
+
+	bt_object_get(NULL);
+	pass("getting NULL does not cause a crash");
+	bt_object_put(NULL);
+	pass("putting NULL does not cause a crash");
+
+	ok(bt_object_get_type(NULL) == BT_OBJECT_TYPE_UNKNOWN,
+		"bt_object_get_type(NULL) returns BT_OBJECT_TYPE_UNKNOWN");
+}
+
+static
+void test_bool(void)
+{
+	int ret;
+	bool value;
+	struct bt_object *obj;
+
+	obj = bt_object_bool_create();
+	ok(obj && bt_object_is_bool(obj),
+		"bt_object_bool_create() returns a boolean object");
+
+	value = true;
+	ret = bt_object_bool_get(obj, &value);
+	ok(!ret && !value, "default boolean object value is false");
+
+	ret = bt_object_bool_set(NULL, true);
+	ok(ret, "bt_object_bool_set() fails with an object set to NULL");
+	ret = bt_object_bool_get(NULL, &value);
+	ok(ret, "bt_object_bool_get() fails with an object set to NULL");
+
+	ret = bt_object_bool_set(obj, true);
+	ok(!ret, "bt_object_bool_set() succeeds");
+	ret = bt_object_bool_get(obj, &value);
+	ok(!ret && value, "bt_object_bool_set() works");
+
+	BT_OBJECT_PUT(obj);
+	pass("putting an existing boolean object does not cause a crash")
+
+	obj = bt_object_bool_create_init(true);
+	ok(obj && bt_object_is_bool(obj),
+		"bt_object_bool_create_init() returns a boolean object");
+	ret = bt_object_bool_get(obj, &value);
+	ok(!ret && value,
+		"bt_object_bool_create_init() sets the appropriate initial value");
+
+	BT_OBJECT_PUT(obj);
+}
+
+static
+void test_integer(void)
+{
+	int ret;
+	int64_t value;
+	struct bt_object *obj;
+
+	obj = bt_object_integer_create();
+	ok(obj && bt_object_is_integer(obj),
+		"bt_object_integer_create() returns an integer object");
+
+	ret = bt_object_integer_set(NULL, -12345);
+	ok(ret, "bt_object_integer_set() fails with an object set to NULL");
+	ret = bt_object_integer_get(NULL, &value);
+	ok(ret, "bt_object_integer_get() fails with an object set to NULL");
+
+	value = 1961;
+	ret = bt_object_integer_get(obj, &value);
+	ok(!ret && value == 0, "default integer object value is 0");
+
+	ret = bt_object_integer_set(obj, -12345);
+	ok(!ret, "bt_object_integer_set() succeeds");
+	ret = bt_object_integer_get(obj, &value);
+	ok(!ret && value == -12345, "bt_object_integer_set() works");
+
+	BT_OBJECT_PUT(obj);
+	pass("putting an existing integer object does not cause a crash")
+
+	obj = bt_object_integer_create_init(321456987);
+	ok(obj && bt_object_is_integer(obj),
+		"bt_object_integer_create_init() returns an integer object");
+	ret = bt_object_integer_get(obj, &value);
+	ok(!ret && value == 321456987,
+		"bt_object_integer_create_init() sets the appropriate initial value");
+
+	BT_OBJECT_PUT(obj);
+}
+
+static
+void test_float(void)
+{
+	int ret;
+	double value;
+	struct bt_object *obj;
+
+	obj = bt_object_float_create();
+	ok(obj && bt_object_is_float(obj),
+		"bt_object_float_create() returns a floating point number object");
+
+	ret = bt_object_float_set(NULL, 1.2345);
+	ok(ret, "bt_object_float_set() fails with an object set to NULL");
+	ret = bt_object_float_get(NULL, &value);
+	ok(ret, "bt_object_float_get() fails with an object set to NULL");
+
+	value = 17.34;
+	ret = bt_object_float_get(obj, &value);
+	ok(!ret && value == 0., "default floating point number object value is 0");
+
+	ret = bt_object_float_set(obj, -3.1416);
+	ok(!ret, "bt_object_float_set() succeeds");
+	ret = bt_object_float_get(obj, &value);
+	ok(!ret && value == -3.1416, "bt_object_float_set() works");
+
+	BT_OBJECT_PUT(obj);
+	pass("putting an existing floating point number object does not cause a crash")
+
+	obj = bt_object_float_create_init(33.1649758);
+	ok(obj && bt_object_is_float(obj),
+		"bt_object_float_create_init() returns a floating point number object");
+	ret = bt_object_float_get(obj, &value);
+	ok(!ret && value == 33.1649758,
+		"bt_object_float_create_init() sets the appropriate initial value");
+
+	BT_OBJECT_PUT(obj);
+}
+
+static
+void test_string(void)
+{
+	int ret;
+	const char *value;
+	struct bt_object *obj;
+
+	obj = bt_object_string_create();
+	ok(obj && bt_object_is_string(obj),
+		"bt_object_string_create() returns a string object");
+
+	ret = bt_object_string_set(NULL, "hoho");
+	ok(ret, "bt_object_string_set() fails with an object set to NULL");
+	value = bt_object_string_get(NULL);
+	ok(!value, "bt_object_string_get() fails with an object set to NULL");
+
+	value = bt_object_string_get(obj);
+	ok(value && !strcmp(value, ""),
+		"default string object value is \"\"");
+
+	ret = bt_object_string_set(obj, "hello worldz");
+	ok(!ret, "bt_object_string_set() succeeds");
+	value = bt_object_string_get(obj);
+	ok(value && !strcmp(value, "hello worldz"),
+		"bt_object_string_set() works");
+	ret = bt_object_string_set(obj, NULL);
+	ok(ret, "bt_object_string_set() does not accept a NULL value");
+
+	BT_OBJECT_PUT(obj);
+	pass("putting an existing string object does not cause a crash")
+
+	obj = bt_object_string_create_init(NULL);
+	ok(!obj, "bt_object_string_create_init() fails with an initial value set to NULL");
+	obj = bt_object_string_create_init("initial value");
+	ok(obj && bt_object_is_string(obj),
+		"bt_object_string_create_init() returns a string object");
+	value = bt_object_string_get(obj);
+	ok(value && !strcmp(value, "initial value"),
+		"bt_object_string_create_init() sets the appropriate initial value");
+
+	BT_OBJECT_PUT(obj);
+}
+
+static
+void test_array(void)
+{
+	int ret;
+	bool bool_value;
+	int64_t int_value;
+	double float_value;
+	struct bt_object *obj;
+	const char *string_value;
+	struct bt_object *array_obj;
+
+	array_obj = bt_object_array_create();
+	ok(array_obj && bt_object_is_array(array_obj),
+		"bt_object_array_create() returns an array object");
+	ok(bt_object_array_is_empty(array_obj),
+		"initial array object size is 0");
+	ok(bt_object_array_size(NULL) < 0,
+		"bt_object_array_size() fails with an array object set to NULL");
+
+	ok(bt_object_array_append(NULL, bt_object_null),
+		"bt_object_array_append() fails with an array object set to NULL");
+
+	obj = bt_object_integer_create_init(345);
+	ret = bt_object_array_append(array_obj, obj);
+	BT_OBJECT_PUT(obj);
+	obj = bt_object_float_create_init(-17.45);
+	ret |= bt_object_array_append(array_obj, obj);
+	BT_OBJECT_PUT(obj);
+	obj = bt_object_bool_create_init(true);
+	ret |= bt_object_array_append(array_obj, obj);
+	BT_OBJECT_PUT(obj);
+	ret |= bt_object_array_append(array_obj, bt_object_null);
+	ok(!ret, "bt_object_array_append() succeeds");
+	ret = bt_object_array_append(NULL, bt_object_null);
+	ok(ret, "bt_object_array_append() fails with an array object set to NULL");
+	ret = bt_object_array_append(array_obj, NULL);
+	ok(ret, "bt_object_array_append() fails with an element object set to NULL");
+	ok(bt_object_array_size(array_obj) == 4,
+		"appending an element to an array object increment its size");
+
+	obj = bt_object_array_get(array_obj, 4);
+	ok(!obj, "getting an array object's element at an index equal to its size fails");
+	obj = bt_object_array_get(array_obj, 5);
+	ok(!obj, "getting an array object's element at a larger index fails");
+
+	obj = bt_object_array_get(NULL, 2);
+	ok(!obj, "bt_object_array_get() fails with an array object set to NULL");
+
+	obj = bt_object_array_get(array_obj, 0);
+	ok(obj && bt_object_is_integer(obj),
+		"bt_object_array_get() returns an object with the appropriate type (integer)");
+	ret = bt_object_integer_get(obj, &int_value);
+	ok(!ret && int_value == 345,
+		"bt_object_array_get() returns an object with the appropriate value (integer)");
+	BT_OBJECT_PUT(obj);
+	obj = bt_object_array_get(array_obj, 1);
+	ok(obj && bt_object_is_float(obj),
+		"bt_object_array_get() returns an object with the appropriate type (floating point number)");
+	ret = bt_object_float_get(obj, &float_value);
+	ok(!ret && float_value == -17.45,
+		"bt_object_array_get() returns an object with the appropriate value (floating point number)");
+	BT_OBJECT_PUT(obj);
+	obj = bt_object_array_get(array_obj, 2);
+	ok(obj && bt_object_is_bool(obj),
+		"bt_object_array_get() returns an object with the appropriate type (boolean)");
+	ret = bt_object_bool_get(obj, &bool_value);
+	ok(!ret && bool_value,
+		"bt_object_array_get() returns an object with the appropriate value (boolean)");
+	BT_OBJECT_PUT(obj);
+	obj = bt_object_array_get(array_obj, 3);
+	ok(obj == bt_object_null,
+		"bt_object_array_get() returns an object with the appropriate type (null)");
+
+	ret = bt_object_array_append_bool(array_obj, false);
+	ok(!ret, "bt_object_array_append_bool() succeeds");
+	ret = bt_object_array_append_bool(NULL, true);
+	ok(ret, "bt_object_array_append_bool() fails with an array object set to NULL");
+	ret = bt_object_array_append_integer(array_obj, 98765);
+	ok(!ret, "bt_object_array_append_integer() succeeds");
+	ret = bt_object_array_append_integer(NULL, 18765);
+	ok(ret, "bt_object_array_append_integer() fails with an array object set to NULL");
+	ret = bt_object_array_append_float(array_obj, 2.49578);
+	ok(!ret, "bt_object_array_append_float() succeeds");
+	ret = bt_object_array_append_float(NULL, 1.49578);
+	ok(ret, "bt_object_array_append_float() fails with an array object set to NULL");
+	ret = bt_object_array_append_string(array_obj, "bt_object");
+	ok(!ret, "bt_object_array_append_string() succeeds");
+	ret = bt_object_array_append_string(NULL, "bt_obj");
+	ok(ret, "bt_object_array_append_string() fails with an array object set to NULL");
+	ret = bt_object_array_append_array(array_obj);
+	ok(!ret, "bt_object_array_append_array() succeeds");
+	ret = bt_object_array_append_array(NULL);
+	ok(ret, "bt_object_array_append_array() fails with an array object set to NULL");
+	ret = bt_object_array_append_map(array_obj);
+	ok(!ret, "bt_object_array_append_map() succeeds");
+	ret = bt_object_array_append_map(NULL);
+	ok(ret, "bt_object_array_append_map() fails with an array object set to NULL");
+
+	ok(bt_object_array_size(array_obj) == 10,
+		"the bt_object_array_append_*() functions increment the array object's size");
+	ok(!bt_object_array_is_empty(array_obj),
+		"map object is not empty");
+
+	obj = bt_object_array_get(array_obj, 4);
+	ok(obj && bt_object_is_bool(obj),
+		"bt_object_array_append_bool() appends a boolean object");
+	ret = bt_object_bool_get(obj, &bool_value);
+	ok(!ret && !bool_value,
+		"bt_object_array_append_bool() appends the appropriate value");
+	BT_OBJECT_PUT(obj);
+	obj = bt_object_array_get(array_obj, 5);
+	ok(obj && bt_object_is_integer(obj),
+		"bt_object_array_append_integer() appends an integer object");
+	ret = bt_object_integer_get(obj, &int_value);
+	ok(!ret && int_value == 98765,
+		"bt_object_array_append_integer() appends the appropriate value");
+	BT_OBJECT_PUT(obj);
+	obj = bt_object_array_get(array_obj, 6);
+	ok(obj && bt_object_is_float(obj),
+		"bt_object_array_append_float() appends a floating point number object");
+	ret = bt_object_float_get(obj, &float_value);
+	ok(!ret && float_value == 2.49578,
+		"bt_object_array_append_float() appends the appropriate value");
+	BT_OBJECT_PUT(obj);
+	obj = bt_object_array_get(array_obj, 7);
+	ok(obj && bt_object_is_string(obj),
+		"bt_object_array_append_string() appends a string object");
+	string_value = bt_object_string_get(obj);
+	ok(string_value && !strcmp(string_value, "bt_object"),
+		"bt_object_array_append_string() appends the appropriate value");
+	BT_OBJECT_PUT(obj);
+	obj = bt_object_array_get(array_obj, 8);
+	ok(obj && bt_object_is_array(obj),
+		"bt_object_array_append_array() appends an array object");
+	ok(bt_object_array_is_empty(obj),
+		"bt_object_array_append_array() an empty array object");
+	BT_OBJECT_PUT(obj);
+	obj = bt_object_array_get(array_obj, 9);
+	ok(obj && bt_object_is_map(obj),
+		"bt_object_array_append_map() appends a map object");
+	ok(bt_object_map_is_empty(obj),
+		"bt_object_array_append_map() an empty map object");
+	BT_OBJECT_PUT(obj);
+
+	BT_OBJECT_PUT(array_obj);
+	pass("putting an existing array object does not cause a crash")
+}
+
+static
+bool test_map_foreach_cb_count(const char *key, struct bt_object *object,
+	void *data)
+{
+	int *count = data;
+
+	if (*count == 3) {
+		return false;
+	}
+
+	(*count)++;
+
+	return true;
+}
+
+struct map_foreach_checklist {
+	bool bool1;
+	bool int1;
+	bool float1;
+	bool null1;
+	bool bool2;
+	bool int2;
+	bool float2;
+	bool string2;
+	bool array2;
+	bool map2;
+};
+
+static
+bool test_map_foreach_cb_check(const char *key, struct bt_object *object,
+	void *data)
+{
+	int ret;
+	struct map_foreach_checklist *checklist = data;
+
+	if (!strcmp(key, "bool")) {
+		if (checklist->bool1) {
+			fail("test_map_foreach_cb_check(): duplicate key \"bool\"");
+		} else {
+			bool val = false;
+
+			ret = bt_object_bool_get(object, &val);
+			ok(!ret, "test_map_foreach_cb_check(): success getting \"bool\" value");
+
+			if (val) {
+				pass("test_map_foreach_cb_check(): \"bool\" object has the right value");
+				checklist->bool1 = true;
+			}
+		}
+	} else if (!strcmp(key, "int")) {
+		if (checklist->int1) {
+			fail("test_map_foreach_cb_check(): duplicate key \"int\"");
+		} else {
+			int64_t val = 0;
+
+			ret = bt_object_integer_get(object, &val);
+			ok(!ret, "test_map_foreach_cb_check(): success getting \"int\" value");
+
+			if (val == 19457) {
+				pass("test_map_foreach_cb_check(): \"int\" object has the right value");
+				checklist->int1 = true;
+			}
+		}
+	} else if (!strcmp(key, "float")) {
+		if (checklist->float1) {
+			fail("test_map_foreach_cb_check(): duplicate key \"float\"");
+		} else {
+			double val = 0;
+
+			ret = bt_object_float_get(object, &val);
+			ok(!ret, "test_map_foreach_cb_check(): success getting \"float\" value");
+
+			if (val == 5.444) {
+				pass("test_map_foreach_cb_check(): \"float\" object has the right value");
+				checklist->float1 = true;
+			}
+		}
+	} else if (!strcmp(key, "null")) {
+		if (checklist->null1) {
+			fail("test_map_foreach_cb_check(): duplicate key \"bool\"");
+		} else {
+			ok(bt_object_is_null(object), "test_map_foreach_cb_check(): success getting \"null\" object");
+			checklist->null1 = true;
+		}
+	} else if (!strcmp(key, "bool2")) {
+		if (checklist->bool2) {
+			fail("test_map_foreach_cb_check(): duplicate key \"bool2\"");
+		} else {
+			bool val = false;
+
+			ret = bt_object_bool_get(object, &val);
+			ok(!ret, "test_map_foreach_cb_check(): success getting \"bool2\" value");
+
+			if (val) {
+				pass("test_map_foreach_cb_check(): \"bool2\" object has the right value");
+				checklist->bool2 = true;
+			}
+		}
+	} else if (!strcmp(key, "int2")) {
+		if (checklist->int2) {
+			fail("test_map_foreach_cb_check(): duplicate key \"int2\"");
+		} else {
+			int64_t val = 0;
+
+			ret = bt_object_integer_get(object, &val);
+			ok(!ret, "test_map_foreach_cb_check(): success getting \"int2\" value");
+
+			if (val == 98765) {
+				pass("test_map_foreach_cb_check(): \"int2\" object has the right value");
+				checklist->int2 = true;
+			}
+		}
+	} else if (!strcmp(key, "float2")) {
+		if (checklist->float2) {
+			fail("test_map_foreach_cb_check(): duplicate key \"float2\"");
+		} else {
+			double val = 0;
+
+			ret = bt_object_float_get(object, &val);
+			ok(!ret, "test_map_foreach_cb_check(): success getting \"float2\" value");
+
+			if (val == -49.0001) {
+				pass("test_map_foreach_cb_check(): \"float2\" object has the right value");
+				checklist->float2 = true;
+			}
+		}
+	} else if (!strcmp(key, "string2")) {
+		if (checklist->string2) {
+			fail("test_map_foreach_cb_check(): duplicate key \"string2\"");
+		} else {
+			const char *val = bt_object_string_get(object);
+
+			ok(val, "test_map_foreach_cb_check(): success getting \"string2\" value");
+
+			if (!strcmp(val, "bt_object")) {
+				pass("test_map_foreach_cb_check(): \"string2\" object has the right value");
+				checklist->string2 = true;
+			}
+		}
+	} else if (!strcmp(key, "array2")) {
+		if (checklist->array2) {
+			fail("test_map_foreach_cb_check(): duplicate key \"array2\"");
+		} else {
+			ok(bt_object_is_array(object), "test_map_foreach_cb_check(): success getting \"array2\" object");
+			ok(bt_object_array_is_empty(object),
+				"test_map_foreach_cb_check(): \"array2\" object is empty");
+			checklist->array2 = true;
+		}
+	} else if (!strcmp(key, "map2")) {
+		if (checklist->map2) {
+			fail("test_map_foreach_cb_check(): duplicate key \"map2\"");
+		} else {
+			ok(bt_object_is_map(object), "test_map_foreach_cb_check(): success getting \"map2\" object");
+			ok(bt_object_map_is_empty(object),
+				"test_map_foreach_cb_check(): \"map2\" object is empty");
+			checklist->map2 = true;
+		}
+	} else {
+		diag("test_map_foreach_cb_check(): unknown map key \"%s\"",
+			key);
+		fail("test_map_foreach_cb_check(): unknown map key");
+	}
+
+	return true;
+}
+
+static
+void test_map(void)
+{
+	int ret;
+	int count = 0;
+	bool bool_value;
+	int64_t int_value;
+	double float_value;
+	struct bt_object *obj;
+	struct bt_object *map_obj;
+	struct map_foreach_checklist checklist;
+
+	map_obj = bt_object_map_create();
+	ok(map_obj && bt_object_is_map(map_obj),
+		"bt_object_map_create() returns a map object");
+	ok(bt_object_map_size(map_obj) == 0,
+		"initial map object size is 0");
+	ok(bt_object_map_size(NULL) < 0,
+		"bt_object_map_size() fails with a map object set to NULL");
+
+	ok(bt_object_map_insert(NULL, "hello", bt_object_null),
+		"bt_object_array_insert() fails with a map object set to NULL");
+
+	ok(bt_object_map_insert(map_obj, NULL, bt_object_null),
+		"bt_object_array_insert() fails with a key set to NULL");
+	ok(bt_object_map_insert(map_obj, "yeah", NULL),
+		"bt_object_array_insert() fails with an element object set to NULL");
+
+	obj = bt_object_integer_create_init(19457);
+	ret = bt_object_map_insert(map_obj, "int", obj);
+	BT_OBJECT_PUT(obj);
+	obj = bt_object_float_create_init(5.444);
+	ret |= bt_object_map_insert(map_obj, "float", obj);
+	BT_OBJECT_PUT(obj);
+	obj = bt_object_bool_create();
+	ret |= bt_object_map_insert(map_obj, "bool", obj);
+	BT_OBJECT_PUT(obj);
+	ret |= bt_object_map_insert(map_obj, "null", bt_object_null);
+	ok(!ret, "bt_object_map_insert() succeeds");
+	ok(bt_object_map_size(map_obj) == 4,
+		"inserting an element into a map object increment its size");
+
+	obj = bt_object_bool_create_init(true);
+	ret = bt_object_map_insert(map_obj, "bool", obj);
+	BT_OBJECT_PUT(obj);
+	ok(!ret, "bt_object_map_insert() accepts an existing key");
+
+	obj = bt_object_map_get(map_obj, NULL);
+	ok(!obj, "bt_object_map_get() fails with a key set to NULL");
+	obj = bt_object_map_get(NULL, "bool");
+	ok(!obj, "bt_object_map_get() fails with a map object set to NULL");
+
+	obj = bt_object_map_get(map_obj, "life");
+	ok(!obj, "bt_object_map_get() fails with an non existing key");
+	obj = bt_object_map_get(map_obj, "float");
+	ok(obj && bt_object_is_float(obj),
+		"bt_object_map_get() returns an object with the appropriate type (float)");
+	ret = bt_object_float_get(obj, &float_value);
+	ok(!ret && float_value == 5.444,
+		"bt_object_map_get() returns an object with the appropriate value (float)");
+	BT_OBJECT_PUT(obj);
+	obj = bt_object_map_get(map_obj, "int");
+	ok(obj && bt_object_is_integer(obj),
+		"bt_object_map_get() returns an object with the appropriate type (integer)");
+	ret = bt_object_integer_get(obj, &int_value);
+	ok(!ret && int_value == 19457,
+		"bt_object_map_get() returns an object with the appropriate value (integer)");
+	BT_OBJECT_PUT(obj);
+	obj = bt_object_map_get(map_obj, "null");
+	ok(obj && bt_object_is_null(obj),
+		"bt_object_map_get() returns an object with the appropriate type (null)");
+	obj = bt_object_map_get(map_obj, "bool");
+	ok(obj && bt_object_is_bool(obj),
+		"bt_object_map_get() returns an object with the appropriate type (boolean)");
+	ret = bt_object_bool_get(obj, &bool_value);
+	ok(!ret && bool_value,
+		"bt_object_map_get() returns an object with the appropriate value (boolean)");
+	BT_OBJECT_PUT(obj);
+
+	ret = bt_object_map_insert_bool(map_obj, "bool2", true);
+	ok(!ret, "bt_object_map_insert_bool() succeeds");
+	ret = bt_object_map_insert_bool(NULL, "bool2", false);
+	ok(ret, "bt_object_map_insert_bool() fails with a map object set to NULL");
+	ret = bt_object_map_insert_integer(map_obj, "int2", 98765);
+	ok(!ret, "bt_object_map_insert_integer() succeeds");
+	ret = bt_object_map_insert_integer(NULL, "int2", 1001);
+	ok(ret, "bt_object_map_insert_integer() fails with a map object set to NULL");
+	ret = bt_object_map_insert_float(map_obj, "float2", -49.0001);
+	ok(!ret, "bt_object_map_insert_float() succeeds");
+	ret = bt_object_map_insert_float(NULL, "float2", 495);
+	ok(ret, "bt_object_map_insert_float() fails with a map object set to NULL");
+	ret = bt_object_map_insert_string(map_obj, "string2", "bt_object");
+	ok(!ret, "bt_object_map_insert_string() succeeds");
+	ret = bt_object_map_insert_string(NULL, "string2", "bt_obj");
+	ok(ret, "bt_object_map_insert_string() fails with a map object set to NULL");
+	ret = bt_object_map_insert_array(map_obj, "array2");
+	ok(!ret, "bt_object_map_insert_array() succeeds");
+	ret = bt_object_map_insert_array(NULL, "array2");
+	ok(ret, "bt_object_map_insert_array() fails with a map object set to NULL");
+	ret = bt_object_map_insert_map(map_obj, "map2");
+	ok(!ret, "bt_object_map_insert_map() succeeds");
+	ret = bt_object_map_insert_map(NULL, "map2");
+	ok(ret, "bt_object_map_insert_map() fails with a map object set to NULL");
+
+	ok(bt_object_map_size(map_obj) == 10,
+		"the bt_object_map_insert*() functions increment the map object's size");
+
+	ok(!bt_object_map_has_key(map_obj, "hello"),
+		"map object does not have key \"hello\"");
+	ok(bt_object_map_has_key(map_obj, "bool"),
+		"map object has key \"bool\"");
+	ok(bt_object_map_has_key(map_obj, "int"),
+		"map object has key \"int\"");
+	ok(bt_object_map_has_key(map_obj, "float"),
+		"map object has key \"float\"");
+	ok(bt_object_map_has_key(map_obj, "null"),
+		"map object has key \"null\"");
+	ok(bt_object_map_has_key(map_obj, "bool2"),
+		"map object has key \"bool2\"");
+	ok(bt_object_map_has_key(map_obj, "int2"),
+		"map object has key \"int2\"");
+	ok(bt_object_map_has_key(map_obj, "float2"),
+		"map object has key \"float2\"");
+	ok(bt_object_map_has_key(map_obj, "string2"),
+		"map object has key \"string2\"");
+	ok(bt_object_map_has_key(map_obj, "array2"),
+		"map object has key \"array2\"");
+	ok(bt_object_map_has_key(map_obj, "map2"),
+		"map object has key \"map2\"");
+
+	ret = bt_object_map_foreach(NULL, test_map_foreach_cb_count, &count);
+	ok(ret, "bt_object_map_foreach() fails with a map object set to NULL");
+	ret = bt_object_map_foreach(map_obj, NULL, &count);
+	ok(ret, "bt_object_map_foreach() fails with a user function set to NULL");
+	ret = bt_object_map_foreach(map_obj, test_map_foreach_cb_count, &count);
+	ok(!ret && count == 3,
+		"bt_object_map_foreach() breaks the loop when the user function returns false");
+
+	memset(&checklist, 0, sizeof(checklist));
+	ret = bt_object_map_foreach(map_obj, test_map_foreach_cb_check,
+		&checklist);
+	ok(!ret, "bt_object_map_foreach() succeeds with test_map_foreach_cb_check()");
+	ok(checklist.bool1 && checklist.int1 && checklist.float1 &&
+		checklist.null1 && checklist.bool2 && checklist.int2 &&
+		checklist.float2 && checklist.string2 &&
+		checklist.array2 && checklist.map2,
+		"bt_object_map_foreach() iterates over all the map object's elements");
+
+	BT_OBJECT_PUT(map_obj);
+	pass("putting an existing map object does not cause a crash")
+}
+
+static
+void test_types(void)
+{
+	test_null();
+	test_bool();
+	test_integer();
+	test_float();
+	test_string();
+	test_array();
+	test_map();
+}
+
+static
+void test_compare_null(void)
+{
+	ok(!bt_object_compare(bt_object_null, NULL),
+		"cannot compare null object and NULL");
+	ok(!bt_object_compare(NULL, bt_object_null),
+		"cannot compare NULL and null object");
+	ok(bt_object_compare(bt_object_null, bt_object_null),
+		"null objects are equivalent");
+}
+
+static
+void test_compare_bool(void)
+{
+	struct bt_object *bool1 = bt_object_bool_create_init(false);
+	struct bt_object *bool2 = bt_object_bool_create_init(true);
+	struct bt_object *bool3 = bt_object_bool_create_init(false);
+
+	assert(bool1 && bool2 && bool3);
+	ok(!bt_object_compare(bt_object_null, bool1),
+		"cannot compare null object and bool object");
+	ok(!bt_object_compare(bool1, bool2),
+		"integer objects are not equivalent (false and true)");
+	ok(bt_object_compare(bool1, bool3),
+		"integer objects are equivalent (false and false)");
+
+	BT_OBJECT_PUT(bool1);
+	BT_OBJECT_PUT(bool2);
+	BT_OBJECT_PUT(bool3);
+}
+
+static
+void test_compare_integer(void)
+{
+	struct bt_object *int1 = bt_object_integer_create_init(10);
+	struct bt_object *int2 = bt_object_integer_create_init(-23);
+	struct bt_object *int3 = bt_object_integer_create_init(10);
+
+	assert(int1 && int2 && int3);
+	ok(!bt_object_compare(bt_object_null, int1),
+		"cannot compare null object and integer object");
+	ok(!bt_object_compare(int1, int2),
+		"integer objects are not equivalent (10 and -23)");
+	ok(bt_object_compare(int1, int3),
+		"integer objects are equivalent (10 and 10)");
+
+	BT_OBJECT_PUT(int1);
+	BT_OBJECT_PUT(int2);
+	BT_OBJECT_PUT(int3);
+}
+
+static
+void test_compare_float(void)
+{
+	struct bt_object *float1 = bt_object_float_create_init(17.38);
+	struct bt_object *float2 = bt_object_float_create_init(-14.23);
+	struct bt_object *float3 = bt_object_float_create_init(17.38);
+
+	assert(float1 && float2 && float3);
+
+	ok(!bt_object_compare(bt_object_null, float1),
+		"cannot compare null object and floating point number object");
+	ok(!bt_object_compare(float1, float2),
+		"floating point number objects are not equivalent (17.38 and -14.23)");
+	ok(bt_object_compare(float1, float3),
+		"floating point number objects are equivalent (17.38 and 17.38)");
+
+	BT_OBJECT_PUT(float1);
+	BT_OBJECT_PUT(float2);
+	BT_OBJECT_PUT(float3);
+}
+
+static
+void test_compare_string(void)
+{
+	struct bt_object *string1 = bt_object_string_create_init("hello");
+	struct bt_object *string2 = bt_object_string_create_init("bt_object");
+	struct bt_object *string3 = bt_object_string_create_init("hello");
+
+	assert(string1 && string2 && string3);
+
+	ok(!bt_object_compare(bt_object_null, string1),
+		"cannot compare null object and string object");
+	ok(!bt_object_compare(string1, string2),
+		"string objects are not equivalent (\"hello\" and \"bt_object\")");
+	ok(bt_object_compare(string1, string3),
+		"string objects are equivalent (\"hello\" and \"hello\")");
+
+	BT_OBJECT_PUT(string1);
+	BT_OBJECT_PUT(string2);
+	BT_OBJECT_PUT(string3);
+}
+
+static
+void test_compare_array(void)
+{
+	struct bt_object *array1 = bt_object_array_create();
+	struct bt_object *array2 = bt_object_array_create();
+	struct bt_object *array3 = bt_object_array_create();
+
+	assert(array1 && array2 && array3);
+
+	ok(bt_object_compare(array1, array2),
+		"empty array objects are equivalent");
+
+	assert(!bt_object_array_append_integer(array1, 23));
+	assert(!bt_object_array_append_float(array1, 14.2));
+	assert(!bt_object_array_append_bool(array1, false));
+	assert(!bt_object_array_append_float(array2, 14.2));
+	assert(!bt_object_array_append_integer(array2, 23));
+	assert(!bt_object_array_append_bool(array2, false));
+	assert(!bt_object_array_append_integer(array3, 23));
+	assert(!bt_object_array_append_float(array3, 14.2));
+	assert(!bt_object_array_append_bool(array3, false));
+	assert(bt_object_array_size(array1) == 3);
+	assert(bt_object_array_size(array2) == 3);
+	assert(bt_object_array_size(array3) == 3);
+
+	ok(!bt_object_compare(bt_object_null, array1),
+		"cannot compare null object and array object");
+	ok(!bt_object_compare(array1, array2),
+		"array objects are not equivalent ([23, 14.2, false] and [14.2, 23, false])");
+	ok(bt_object_compare(array1, array3),
+		"array objects are equivalent ([23, 14.2, false] and [23, 14.2, false])");
+
+	BT_OBJECT_PUT(array1);
+	BT_OBJECT_PUT(array2);
+	BT_OBJECT_PUT(array3);
+}
+
+static
+void test_compare_map(void)
+{
+	struct bt_object *map1 = bt_object_map_create();
+	struct bt_object *map2 = bt_object_map_create();
+	struct bt_object *map3 = bt_object_map_create();
+
+	assert(map1 && map2 && map3);
+
+	ok(bt_object_compare(map1, map2),
+		"empty map objects are equivalent");
+
+	assert(!bt_object_map_insert_integer(map1, "one", 23));
+	assert(!bt_object_map_insert_float(map1, "two", 14.2));
+	assert(!bt_object_map_insert_bool(map1, "three", false));
+	assert(!bt_object_map_insert_float(map2, "one", 14.2));
+	assert(!bt_object_map_insert_integer(map2, "two", 23));
+	assert(!bt_object_map_insert_bool(map2, "three", false));
+	assert(!bt_object_map_insert_bool(map3, "three", false));
+	assert(!bt_object_map_insert_integer(map3, "one", 23));
+	assert(!bt_object_map_insert_float(map3, "two", 14.2));
+	assert(bt_object_map_size(map1) == 3);
+	assert(bt_object_map_size(map2) == 3);
+	assert(bt_object_map_size(map3) == 3);
+
+	ok(!bt_object_compare(bt_object_null, map1),
+		"cannot compare null object and map object");
+	ok(!bt_object_compare(map1, map2),
+		"map objects are not equivalent");
+	ok(bt_object_compare(map1, map3),
+		"map objects are equivalent");
+
+	BT_OBJECT_PUT(map1);
+	BT_OBJECT_PUT(map2);
+	BT_OBJECT_PUT(map3);
+}
+
+static
+void test_compare(void)
+{
+	ok(!bt_object_compare(NULL, NULL), "cannot compare NULL and NULL");
+	test_compare_null();
+	test_compare_bool();
+	test_compare_integer();
+	test_compare_float();
+	test_compare_string();
+	test_compare_array();
+	test_compare_map();
+}
+
+static
+void test_copy(void)
+{
+	/*
+	 * Here's the deal here. If we make sure that each object
+	 * of our deep copy has a different address than its source,
+	 * and that bt_object_compare() returns true for the top-level
+	 * object, taking into account that we test the correctness of
+	 * bt_object_compare() elsewhere, then the deep copy is a
+	 * success.
+	 */
+	struct bt_object *null_copy_obj;
+	struct bt_object *bool_obj, *bool_copy_obj;
+	struct bt_object *integer_obj, *integer_copy_obj;
+	struct bt_object *float_obj, *float_copy_obj;
+	struct bt_object *string_obj, *string_copy_obj;
+	struct bt_object *array_obj, *array_copy_obj;
+	struct bt_object *map_obj, *map_copy_obj;
+
+	bool_obj = bt_object_bool_create_init(true);
+	integer_obj = bt_object_integer_create_init(23);
+	float_obj = bt_object_float_create_init(-3.1416);
+	string_obj = bt_object_string_create_init("test");
+	array_obj = bt_object_array_create();
+	map_obj = bt_object_map_create();
+
+	assert(bool_obj && integer_obj && float_obj && string_obj &&
+		array_obj && map_obj);
+
+	assert(!bt_object_array_append(array_obj, bool_obj));
+	assert(!bt_object_array_append(array_obj, integer_obj));
+	assert(!bt_object_array_append(array_obj, float_obj));
+	assert(!bt_object_array_append(array_obj, bt_object_null));
+	assert(!bt_object_map_insert(map_obj, "array", array_obj));
+	assert(!bt_object_map_insert(map_obj, "string", string_obj));
+
+	map_copy_obj = bt_object_copy(NULL);
+	ok(!map_copy_obj,
+		"bt_object_copy() fails with a source object set to NULL");
+
+	map_copy_obj = bt_object_copy(map_obj);
+	ok(map_copy_obj,
+		"bt_object_copy() succeeds");
+
+	ok(map_obj != map_copy_obj,
+		"bt_object_copy() returns a different pointer (map)");
+	string_copy_obj = bt_object_map_get(map_copy_obj, "string");
+	ok(string_copy_obj != string_obj,
+		"bt_object_copy() returns a different pointer (string)");
+	array_copy_obj = bt_object_map_get(map_copy_obj, "array");
+	ok(array_copy_obj != array_obj,
+		"bt_object_copy() returns a different pointer (array)");
+	bool_copy_obj = bt_object_array_get(array_copy_obj, 0);
+	ok(bool_copy_obj != bool_obj,
+		"bt_object_copy() returns a different pointer (bool)");
+	integer_copy_obj = bt_object_array_get(array_copy_obj, 1);
+	ok(integer_copy_obj != integer_obj,
+		"bt_object_copy() returns a different pointer (integer)");
+	float_copy_obj = bt_object_array_get(array_copy_obj, 2);
+	ok(float_copy_obj != float_obj,
+		"bt_object_copy() returns a different pointer (float)");
+	null_copy_obj = bt_object_array_get(array_copy_obj, 3);
+	ok(null_copy_obj == bt_object_null,
+		"bt_object_copy() returns the same pointer (null)");
+
+	ok(bt_object_compare(map_obj, map_copy_obj),
+		"source and destination objects have the same content");
+
+	BT_OBJECT_PUT(bool_copy_obj);
+	BT_OBJECT_PUT(integer_copy_obj);
+	BT_OBJECT_PUT(float_copy_obj);
+	BT_OBJECT_PUT(string_copy_obj);
+	BT_OBJECT_PUT(array_copy_obj);
+	BT_OBJECT_PUT(map_copy_obj);
+	BT_OBJECT_PUT(bool_obj);
+	BT_OBJECT_PUT(integer_obj);
+	BT_OBJECT_PUT(float_obj);
+	BT_OBJECT_PUT(string_obj);
+	BT_OBJECT_PUT(array_obj);
+	BT_OBJECT_PUT(map_obj);
+}
+
+static
+void test_macros(void)
+{
+	struct bt_object *obj = bt_object_bool_create();
+	struct bt_object *src;
+	struct bt_object *dst;
+
+	assert(obj);
+	BT_OBJECT_PUT(obj);
+	ok(!obj, "BT_OBJECT_PUT() resets the variable to NULL");
+
+	obj = bt_object_bool_create();
+	assert(obj);
+	src = obj;
+	BT_OBJECT_MOVE(dst, src);
+	ok(!src, "BT_OBJECT_MOVE() resets the source variable to NULL");
+	ok(dst == obj, "BT_OBJECT_MOVE() moves the ownership");
+
+	BT_OBJECT_PUT(dst);
+}
+
+int main(void)
+{
+	plan_no_plan();
+
+	test_macros();
+	test_types();
+	test_compare();
+	test_copy();
+
+	return 0;
+}

--- a/tests/tests
+++ b/tests/tests
@@ -3,3 +3,4 @@ lib/test_bitfield
 lib/test_seek_empty_packet
 lib/test_seek_big_trace
 lib/test_ctf_writer_complete
+lib/test_bt_objects


### PR DESCRIPTION
This patch adds a basic, yet fairly complete, object system to
Babeltrace, or more specifically, to libbabeltrace. The object system,
prefixed with `bt_object`, wraps GLib, but does not expose any
GLib object, making it suitable for public APIs. The object system
features reference counting, and it has deep-copy as well as
deep-compare functions.

The provided test reaches 92.36% of `object.c`'s lines, according
to Gcov, and after having checked the report line by line, the only
blocks that are not covered are those where GLib memory allocation
fails. Valgrind's memory leak detector also shows no lost memory
during the execution of this test.

`object.h` is Doxygen-ready, with a complete file-level documentation
introducing the API, how to use it, and the best practices.