### PR TITLE
ir: add bt_ctf_trace_get_clock_by_name() and tests

### DIFF
--- a/formats/ctf/ir/trace.c
+++ b/formats/ctf/ir/trace.c
@@ -497,6 +497,36 @@ end:
 	return stream_class;
 }
 
+struct bt_ctf_clock *bt_ctf_trace_get_clock_by_name(
+        struct bt_ctf_trace *trace, const char *name)
+{
+	size_t i;
+	struct bt_ctf_clock *clock = NULL;
+
+	if (!trace || !name) {
+		goto end;
+	}
+
+	for (i = 0; i < trace->clocks->len; ++i) {
+		struct bt_ctf_clock *cur_clk =
+			g_ptr_array_index(trace->clocks, i);
+		const char *cur_clk_name = bt_ctf_clock_get_name(cur_clk);
+
+		if (!cur_clk_name) {
+			goto end;
+		}
+
+		if (!strcmp(cur_clk_name, name)) {
+			clock = cur_clk;
+			bt_ctf_clock_get(clock);
+			goto end;
+		}
+	}
+
+end:
+	return clock;
+}
+
 BT_HIDDEN
 const char *get_byte_order_string(int byte_order)
 {

--- a/include/babeltrace/ctf-ir/trace.h
+++ b/include/babeltrace/ctf-ir/trace.h
@@ -254,6 +254,17 @@ extern struct bt_ctf_stream_class *bt_ctf_trace_get_stream_class(
 		struct bt_ctf_trace *trace, int index);
 
 /*
+ * bt_ctf_trace_get_clock_by_name: get a trace's clock by name
+ *
+ * @param trace	Trace instance.
+ * @param name	Name of the clock in the given trace.
+ *
+ * Return a clock instance on success, NULL on error.
+ */
+extern struct bt_ctf_clock *bt_ctf_trace_get_clock_by_name(
+        struct bt_ctf_trace *trace, const char *name);
+
+/*
  * bt_ctf_trace_get_metadata_string: get metadata string.
  *
  * Get the trace's TSDL metadata. The caller assumes the ownership of the

--- a/tests/lib/test_ctf_writer.c
+++ b/tests/lib/test_ctf_writer.c
@@ -1866,6 +1866,18 @@ int main(int argc, char **argv)
 	ok(ret_clock == clock,
 		"bt_ctf_trace_get_clock returns the right clock instance");
 	bt_ctf_clock_put(ret_clock);
+	ok(!bt_ctf_trace_get_clock_by_name(trace, NULL),
+		"bt_ctf_trace_get_clock_by_name correctly handles NULL (trace)");
+	ok(!bt_ctf_trace_get_clock_by_name(NULL, clock_name),
+		"bt_ctf_trace_get_clock_by_name correctly handles NULL (clock name)");
+	ok(!bt_ctf_trace_get_clock_by_name(NULL, NULL),
+		"bt_ctf_trace_get_clock_by_name correctly handles NULL (both)");
+	ret_clock = bt_ctf_trace_get_clock_by_name(trace, clock_name);
+	ok(ret_clock == clock,
+		"bt_ctf_trace_get_clock_by_name returns the right clock instance");
+	bt_ctf_clock_put(ret_clock);
+	ok(!bt_ctf_trace_get_clock_by_name(trace, "random"),
+		"bt_ctf_trace_get_clock_by_name fails when the requested clock doesn't exist");
 
 	ok(!bt_ctf_clock_get_name(NULL),
 		"bt_ctf_clock_get_name correctly handles NULL");


### PR DESCRIPTION
Here's a sequential search for retrieving a registered clock by name in CTF IR.

I made two separate commits like you asked last time, but if this patch is small enough to squash them, let me know.