### PR TITLE
ir: add bt_ctf_stream_class_get_event_class_by_id() and tests

### DIFF
--- a/formats/ctf/ir/stream-class.c
+++ b/formats/ctf/ir/stream-class.c
@@ -335,6 +335,30 @@ end:
 	return event_class;
 }
 
+struct bt_ctf_event_class *bt_ctf_stream_class_get_event_class_by_id(
+		struct bt_ctf_stream_class *stream_class, uint32_t id)
+{
+	size_t i;
+	struct bt_ctf_event_class *event_class = NULL;
+
+	if (!stream_class) {
+		goto end;
+	}
+
+	for (i = 0; i < stream_class->event_classes->len; i++) {
+		struct bt_ctf_event_class *current_event_class =
+			g_ptr_array_index(stream_class->event_classes, i);
+
+		if (bt_ctf_event_class_get_id(current_event_class) == id) {
+			event_class = current_event_class;
+			bt_ctf_event_class_get(event_class);
+			goto end;
+		}
+	}
+end:
+	return event_class;
+}
+
 struct bt_ctf_field_type *bt_ctf_stream_class_get_packet_context_type(
 		struct bt_ctf_stream_class *stream_class)
 {

--- a/include/babeltrace/ctf-ir/stream-class.h
+++ b/include/babeltrace/ctf-ir/stream-class.h
@@ -191,6 +191,18 @@ extern struct bt_ctf_event_class *bt_ctf_stream_class_get_event_class_by_name(
 		struct bt_ctf_stream_class *stream_class, const char *name);
 
 /*
+ * bt_ctf_stream_class_get_event_class_by_name: Get stream class event class by
+ * ID.
+ *
+ * @param stream_class Stream class.
+ * @param id Event class ID.
+ *
+ * Returns event class, NULL on error.
+ */
+extern struct bt_ctf_event_class *bt_ctf_stream_class_get_event_class_by_id(
+		struct bt_ctf_stream_class *stream_class, uint32_t id);
+
+/*
  * bt_ctf_stream_class_get_packet_context_type: get the stream class' packet
  * context type.
  *

--- a/tests/lib/test_ctf_writer.c
+++ b/tests/lib/test_ctf_writer.c
@@ -455,6 +455,8 @@ void append_simple_event(struct bt_ctf_stream_class *stream_class,
 	bt_ctf_event_class_add_field(simple_event_class, float_type,
 		"float_field");
 
+	assert(!bt_ctf_event_class_set_id(simple_event_class, 13));
+
 	/* Set an event context type which will contain a single integer*/
 	ok(!bt_ctf_field_type_structure_add_field(event_context_type, uint_12_type,
 		"event_specific_context"),
@@ -488,6 +490,15 @@ void append_simple_event(struct bt_ctf_stream_class *stream_class,
 	ret_event_class = bt_ctf_stream_class_get_event_class(stream_class, 0);
 	ok(ret_event_class == simple_event_class,
 		"bt_ctf_stream_class_get_event_class returns the correct event class");
+	bt_ctf_event_class_put(ret_event_class);
+	ok(!bt_ctf_stream_class_get_event_class_by_id(NULL, 0),
+		"bt_ctf_stream_class_get_event_class_by_id handles NULL correctly");
+	ok(!bt_ctf_stream_class_get_event_class_by_id(stream_class, 2),
+		"bt_ctf_stream_class_get_event_class_by_id returns NULL when the requested ID doesn't exist");
+	ret_event_class =
+		bt_ctf_stream_class_get_event_class_by_id(stream_class, 13);
+	ok(ret_event_class == simple_event_class,
+		"bt_ctf_stream_class_get_event_class_by_id returns a correct event class");
 	bt_ctf_event_class_put(ret_event_class);
 
 	ok(bt_ctf_stream_class_get_event_class_by_name(NULL, "some event name") == NULL,


### PR DESCRIPTION
This is a copy of the function above, `bt_ctf_stream_class_get_event_class_by_name()`, to get an event class by ID.