### PR TITLE
IR: use bt_object for environment, event attributes; some fixes, and add tests for all that

### DIFF
--- a/formats/ctf/ir/stream-class.c
+++ b/formats/ctf/ir/stream-class.c
@@ -220,6 +220,50 @@ end:
 	return ret;
 }
 
+static
+void event_class_exists(gpointer element, gpointer query)
+{
+	struct bt_ctf_event_class *event_class_a = element;
+	struct search_query *search_query = query;
+	struct bt_ctf_event_class *event_class_b = search_query->value;
+	int64_t id_a, id_b;
+
+	if (search_query->value == element) {
+		search_query->found = 1;
+		goto end;
+	}
+
+	/*
+	 * Two event classes cannot share the same name in a given
+	 * stream class.
+	 */
+	if (!strcmp(bt_ctf_event_class_get_name(event_class_a),
+			bt_ctf_event_class_get_name(event_class_b))) {
+		search_query->found = 1;
+		goto end;
+	}
+
+	/*
+	 * Two event classes cannot share the same ID in a given
+	 * stream class.
+	 */
+	id_a = bt_ctf_event_class_get_id(event_class_a);
+	id_b = bt_ctf_event_class_get_id(event_class_b);
+
+	if (id_a < 0 || id_b < 0) {
+		/* at least one ID is not set: will be automatically set later */
+		goto end;
+	}
+
+	if (id_a == id_b) {
+		search_query->found = 1;
+		goto end;
+	}
+
+end:
+	return;
+}
+
 int bt_ctf_stream_class_add_event_class(
 		struct bt_ctf_stream_class *stream_class,
 		struct bt_ctf_event_class *event_class)
@@ -234,7 +278,8 @@ int bt_ctf_stream_class_add_event_class(
 
 	/* Check for duplicate event classes */
 	struct search_query query = { .value = event_class, .found = 0 };
-	g_ptr_array_foreach(stream_class->event_classes, value_exists, &query);
+	g_ptr_array_foreach(stream_class->event_classes, event_class_exists,
+		&query);
 	if (query.found) {
 		ret = -1;
 		goto end;

--- a/formats/ctf/ir/stream-class.c
+++ b/formats/ctf/ir/stream-class.c
@@ -309,24 +309,20 @@ struct bt_ctf_event_class *bt_ctf_stream_class_get_event_class_by_name(
 		struct bt_ctf_stream_class *stream_class, const char *name)
 {
 	size_t i;
-	GQuark name_quark;
 	struct bt_ctf_event_class *event_class = NULL;
 
 	if (!stream_class || !name) {
 		goto end;
 	}
 
-	name_quark = g_quark_try_string(name);
-	if (!name_quark) {
-		goto end;
-	}
-
 	for (i = 0; i < stream_class->event_classes->len; i++) {
-		struct bt_ctf_event_class *current_event_class =
+		struct bt_ctf_event_class *cur_event_class =
 			g_ptr_array_index(stream_class->event_classes, i);
+		const char *cur_event_class_name =
+			bt_ctf_event_class_get_name(cur_event_class);
 
-		if (name_quark == current_event_class->name) {
-			event_class = current_event_class;
+		if (!strcmp(name, cur_event_class_name)) {
+			event_class = cur_event_class;
 			bt_ctf_event_class_get(event_class);
 			goto end;
 		}

--- a/formats/ctf/ir/utils.c
+++ b/formats/ctf/ir/utils.c
@@ -29,6 +29,11 @@
 #include <string.h>
 #include <stdlib.h>
 #include <glib.h>
+#include <babeltrace/babeltrace-internal.h>
+#include <babeltrace/objects.h>
+
+#define BT_CTF_ATTR_NAME_INDEX		0
+#define BT_CTF_ATTR_VALUE_INDEX		1
 
 static
 const char * const reserved_keywords_str[] = {"align", "callsite",
@@ -102,5 +107,267 @@ int bt_ctf_validate_identifier(const char *input_string)
 	}
 end:
 	free(string);
+	return ret;
+}
+
+BT_HIDDEN
+struct bt_object *bt_ctf_attributes_create(void)
+{
+	/*
+	 * Attributes: array object of array objects, each one
+	 * containing two entries: a string object (attributes field
+	 * name), and an object (attributes field value).
+	 *
+	 * Example (JSON representation):
+	 *
+	 *     [
+	 *         ["hostname", "eeppdesk"],
+	 *         ["sysname", "Linux"],
+	 *         ["tracer_major", 2],
+	 *         ["tracer_minor", 5]
+	 *     ]
+	 */
+	return bt_object_array_create();
+}
+
+BT_HIDDEN
+void bt_ctf_attributes_destroy(struct bt_object *attr_obj)
+{
+	bt_object_put(attr_obj);
+}
+
+BT_HIDDEN
+int bt_ctf_attributes_get_count(struct bt_object *attr_obj)
+{
+	return bt_object_array_size(attr_obj);
+}
+
+BT_HIDDEN
+const char *bt_ctf_attributes_get_field_name(struct bt_object *attr_obj,
+		int index)
+{
+	int rc;
+	const char *ret = NULL;
+	struct bt_object *attr_field_obj = NULL;
+	struct bt_object *attr_field_name_obj = NULL;
+
+	if (!attr_obj || index < 0) {
+		goto end;
+	}
+
+	attr_field_obj = bt_object_array_get(attr_obj, index);
+
+	if (!attr_field_obj) {
+		goto end;
+	}
+
+	attr_field_name_obj = bt_object_array_get(attr_field_obj,
+		BT_CTF_ATTR_NAME_INDEX);
+
+	if (!attr_field_name_obj) {
+		goto end;
+	}
+
+	rc = bt_object_string_get(attr_field_name_obj, &ret);
+
+	if (rc) {
+		ret = NULL;
+	}
+
+end:
+	BT_OBJECT_PUT(attr_field_name_obj);
+	BT_OBJECT_PUT(attr_field_obj);
+
+	return ret;
+}
+
+BT_HIDDEN
+struct bt_object *bt_ctf_attributes_get_field_value(struct bt_object *attr_obj,
+		int index)
+{
+	struct bt_object *value_obj = NULL;
+	struct bt_object *attr_field_obj = NULL;
+
+	if (!attr_obj || index < 0) {
+		goto end;
+	}
+
+	attr_field_obj = bt_object_array_get(attr_obj, index);
+
+	if (!attr_field_obj) {
+		goto end;
+	}
+
+	value_obj = bt_object_array_get(attr_field_obj,
+		BT_CTF_ATTR_VALUE_INDEX);
+
+end:
+	BT_OBJECT_PUT(attr_field_obj);
+
+	return value_obj;
+}
+
+static
+struct bt_object *bt_ctf_attributes_get_field_by_name(
+		struct bt_object *attr_obj, const char *name)
+{
+	int i;
+	int attr_size;
+	struct bt_object *value_obj = NULL;
+	struct bt_object *attr_field_name_obj = NULL;
+
+	attr_size = bt_object_array_size(attr_obj);
+
+	if (attr_size < 0) {
+		goto error;
+	}
+
+	for (i = 0; i < attr_size; ++i) {
+		int ret;
+		const char *field_name;
+
+		value_obj = bt_object_array_get(attr_obj, i);
+
+		if (!value_obj) {
+			goto error;
+		}
+
+		attr_field_name_obj = bt_object_array_get(value_obj, 0);
+
+		if (!attr_field_name_obj) {
+			goto error;
+		}
+
+		ret = bt_object_string_get(attr_field_name_obj, &field_name);
+		if (ret) {
+			goto error;
+		}
+
+		if (!strcmp(field_name, name)) {
+			BT_OBJECT_PUT(attr_field_name_obj);
+			break;
+		}
+
+		BT_OBJECT_PUT(attr_field_name_obj);
+		BT_OBJECT_PUT(value_obj);
+	}
+
+	return value_obj;
+
+error:
+	BT_OBJECT_PUT(attr_field_name_obj);
+	BT_OBJECT_PUT(value_obj);
+
+	return value_obj;
+}
+
+BT_HIDDEN
+int bt_ctf_attributes_set_field_value(struct bt_object *attr_obj,
+		const char *name, struct bt_object *value_obj)
+{
+	int ret = 0;
+	struct bt_object *attr_field_obj = NULL;
+
+	if (!attr_obj || !name || !value_obj) {
+		ret = -1;
+		goto end;
+	}
+
+	attr_field_obj = bt_ctf_attributes_get_field_by_name(attr_obj, name);
+
+	if (attr_field_obj) {
+		ret = bt_object_array_set(attr_field_obj,
+			BT_CTF_ATTR_VALUE_INDEX, value_obj);
+		goto end;
+	}
+
+	attr_field_obj = bt_object_array_create();
+
+	if (!attr_field_obj) {
+		ret = -1;
+		goto end;
+	}
+
+	ret = bt_object_array_append_string(attr_field_obj, name);
+	ret |= bt_object_array_append(attr_field_obj, value_obj);
+
+	if (ret) {
+		goto end;
+	}
+
+	ret = bt_object_array_append(attr_obj, attr_field_obj);
+
+end:
+	BT_OBJECT_PUT(attr_field_obj);
+
+	return ret;
+}
+
+BT_HIDDEN
+struct bt_object *bt_ctf_attributes_get_field_value_by_name(
+		struct bt_object *attr_obj, const char *name)
+{
+	struct bt_object *value_obj = NULL;
+	struct bt_object *attr_field_obj = NULL;
+
+	if (!attr_obj || !name) {
+		goto end;
+	}
+
+	attr_field_obj = bt_ctf_attributes_get_field_by_name(attr_obj, name);
+
+	if (!attr_field_obj) {
+		goto end;
+	}
+
+	value_obj = bt_object_array_get(attr_field_obj,
+		BT_CTF_ATTR_VALUE_INDEX);
+
+end:
+	BT_OBJECT_PUT(attr_field_obj);
+
+	return value_obj;
+}
+
+BT_HIDDEN
+int bt_ctf_attributes_freeze(struct bt_object *attr_obj)
+{
+	int i;
+	int count;
+	int ret = 0;
+
+	if (!attr_obj) {
+		ret = -1;
+		goto end;
+	}
+
+	count = bt_object_array_size(attr_obj);
+
+	if (count < 0) {
+		ret = -1;
+		goto end;
+	}
+
+	/*
+	 * We do not freeze the array itself here, since internal
+	 * stuff could need to modify/add attributes. Each attribute
+	 * is frozen one by one.
+	 */
+	for (i = 0; i < count; ++i) {
+		struct bt_object *obj = NULL;
+
+		obj = bt_ctf_attributes_get_field_value(attr_obj, i);
+
+		if (!obj) {
+			ret = -1;
+			goto end;
+		}
+
+		bt_object_freeze(obj);
+		BT_OBJECT_PUT(obj);
+	}
+
+end:
+
 	return ret;
 }

--- a/formats/ctf/writer/writer.c
+++ b/formats/ctf/writer/writer.c
@@ -180,7 +180,7 @@ int bt_ctf_writer_add_environment_field(struct bt_ctf_writer *writer,
 		goto end;
 	}
 
-	ret = bt_ctf_trace_add_environment_field(writer->trace,
+	ret = bt_ctf_trace_set_environment_field_string(writer->trace,
 		name, value);
 end:
 	return ret;

--- a/include/babeltrace/ctf-ir/event-internal.h
+++ b/include/babeltrace/ctf-ir/event-internal.h
@@ -31,14 +31,16 @@
 #include <babeltrace/ctf-writer/event-types.h>
 #include <babeltrace/ctf-writer/event-fields.h>
 #include <babeltrace/babeltrace-internal.h>
+#include <babeltrace/objects.h>
 #include <babeltrace/ctf/types.h>
 #include <glib.h>
 
+#define BT_CTF_EVENT_CLASS_ATTR_ID_INDEX	0
+#define BT_CTF_EVENT_CLASS_ATTR_NAME_INDEX	1
+
 struct bt_ctf_event_class {
 	struct bt_ctf_ref ref_count;
-	GQuark name;
-	int id_set;
-	uint32_t id;
+	struct bt_object *attributes;
 	/* An event class does not have ownership of a stream class */
 	struct bt_ctf_stream_class *stream_class;
 	/* Structure type containing the event's context */

--- a/include/babeltrace/ctf-ir/event.h
+++ b/include/babeltrace/ctf-ir/event.h
@@ -32,6 +32,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <babeltrace/objects.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -90,6 +91,96 @@ extern int64_t bt_ctf_event_class_get_id(
  */
 extern int bt_ctf_event_class_set_id(
 		struct bt_ctf_event_class *event_class, uint32_t id);
+
+/*
+ * bt_ctf_event_class_set_attribute: sets an attribute to the event
+ *	class.
+ *
+ * Sets an attribute to the event class. The name parameter is copied,
+ * whereas the value parameter's reference count is incremented
+ * (if the function succeeds).
+ *
+ * If an attribute exists in the event class for the specified name, it
+ * is replaced by the new value.
+ *
+ * Valid attributes and object types are:
+ *
+ *   - "id":            integer object with a value >= 0
+ *   - "name":          string object
+ *   - "loglevel":      integer object with a value >= 0
+ *   - "model.emf.uri": string object
+ *
+ * @param event_class Event class.
+ * @param name Name of the attribute (will be copied).
+ * @param value Value of the attribute.
+ *
+ * Returns 0 on success, a negative value on error.
+ */
+extern int bt_ctf_event_class_set_attribute(
+		struct bt_ctf_event_class *event_class, const char *name,
+		struct bt_object *value);
+
+/*
+ * bt_ctf_event_class_get_attribute_count: get the number of attributes
+ *	in this event class.
+ *
+ * Get the event class' attribute count.
+ *
+ * @param event_class Event class.
+ *
+ * Returns the attribute count, a negative value on error.
+ */
+extern int bt_ctf_event_class_get_attribute_count(
+		struct bt_ctf_event_class *event_class);
+
+/*
+ * bt_ctf_event_class_get_attribute_name: get attribute name.
+ *
+ * Get an attribute's name. The string's ownership is not
+ * transferred to the caller. The string data is valid as long as
+ * this event class' attributes are not modified.
+ *
+ * @param event_class Event class.
+ * @param index Index of the attribute.
+ *
+ * Returns the attribute's name, NULL on error.
+ */
+extern const char *
+bt_ctf_event_class_get_attribute_name(
+		struct bt_ctf_event_class *event_class, int index);
+
+/*
+ * bt_ctf_event_class_get_attribute_value: get attribute value (an object).
+ *
+ * Get an attribute's value (an object). The returned object's
+ * reference count is incremented. When done with the object, the caller
+ * must call bt_object_put() on it.
+ *
+ * @param event_class Event class.
+ * @param index Index of the attribute.
+ *
+ * Returns the attribute's object value, NULL on error.
+ */
+extern struct bt_object *
+bt_ctf_event_class_get_attribute_value(struct bt_ctf_event_class *event_class,
+		int index);
+
+/*
+ * bt_ctf_event_class_get_attribute_value_by_name: get attribute
+ *	value (an object) by name.
+ *
+ * Get an attribute's value (an object) by its name. The returned object's
+ * reference count is incremented. When done with the object, the caller
+ * must call bt_object_put() on it.
+ *
+ * @param event_class Event class.
+ * @param name Attribute's name
+ *
+ * Returns the attribute's object value, NULL on error.
+ */
+extern struct bt_object *
+bt_ctf_event_class_get_attribute_value_by_name(
+		struct bt_ctf_event_class *event_class, const char *name);
 
 /*
  * bt_ctf_event_class_get_stream_class: Get an event class' stream class.

--- a/include/babeltrace/ctf-ir/trace-internal.h
+++ b/include/babeltrace/ctf-ir/trace-internal.h
@@ -32,6 +32,7 @@
 #include <babeltrace/ctf-ir/event-types.h>
 #include <babeltrace/ctf-ir/event-fields.h>
 #include <babeltrace/babeltrace-internal.h>
+#include <babeltrace/objects.h>
 #include <glib.h>
 #include <sys/types.h>
 #include <uuid/uuid.h>
@@ -51,7 +52,7 @@ struct bt_ctf_trace {
 	int frozen;
 	uuid_t uuid;
 	int byte_order; /* A value defined in Babeltrace's "endian.h" */
-	GPtrArray *environment; /* Array of pointers to environment_variable */
+	struct bt_object *environment;
 	GPtrArray *clocks; /* Array of pointers to bt_ctf_clock */
 	GPtrArray *stream_classes; /* Array of ptrs to bt_ctf_stream_class */
 	GPtrArray *streams; /* Array of ptrs to bt_ctf_stream */

--- a/include/babeltrace/ctf-ir/utils.h
+++ b/include/babeltrace/ctf-ir/utils.h
@@ -34,6 +34,9 @@
 extern "C" {
 #endif
 
+#include <babeltrace/babeltrace-internal.h>
+#include <babeltrace/objects.h>
+
 /*
  * bt_ctf_validate_identifier: validate an identifier against the CTF spec.
  *
@@ -48,6 +51,34 @@ extern "C" {
  * Returns 0 if the identifier is valid, a negative value on error.
  */
 extern int bt_ctf_validate_identifier(const char *identifier);
+
+BT_HIDDEN
+struct bt_object *bt_ctf_attributes_create(void);
+
+BT_HIDDEN
+void bt_ctf_attributes_destroy(struct bt_object *attr_obj);
+
+BT_HIDDEN
+int bt_ctf_attributes_get_count(struct bt_object *attr_obj);
+
+BT_HIDDEN
+const char *bt_ctf_attributes_get_field_name(struct bt_object *attr_obj,
+		int index);
+
+BT_HIDDEN
+struct bt_object *bt_ctf_attributes_get_field_value(struct bt_object *attr_obj,
+		int index);
+
+BT_HIDDEN
+int bt_ctf_attributes_set_field_value(struct bt_object *attr_obj,
+		const char *name, struct bt_object *value_obj);
+
+BT_HIDDEN
+struct bt_object *bt_ctf_attributes_get_field_value_by_name(
+		struct bt_object *attr_obj, const char *name);
+
+BT_HIDDEN
+int bt_ctf_attributes_freeze(struct bt_object *attr_obj);
 
 #ifdef __cplusplus
 }

--- a/tests/lib/test_ctf_writer.c
+++ b/tests/lib/test_ctf_writer.c
@@ -28,6 +28,7 @@
 #include <babeltrace/ctf-writer/event-fields.h>
 #include <babeltrace/ctf-ir/stream-class.h>
 #include <babeltrace/ctf/events.h>
+#include <babeltrace/objects.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -1668,6 +1669,7 @@ int main(int argc, char **argv)
 	struct bt_ctf_trace *trace;
 	int ret;
 	int64_t ret_int64_t;
+	struct bt_object *obj;
 
 	if (argc < 3) {
 		printf("Usage: tests-ctf-writer path_to_ctf_parser_test path_to_babeltrace\n");
@@ -1713,64 +1715,123 @@ int main(int argc, char **argv)
 	ok(bt_ctf_writer_add_environment_field(writer, "test_field",
 		NULL),
 		"bt_ctf_writer_add_environment_field error with NULL field value");
-	ok(bt_ctf_trace_add_environment_field_integer(NULL, "test_env", 0),
-		"bt_ctf_trace_add_environment_field_integer handles a NULL trace correctly");
-	ok(bt_ctf_trace_add_environment_field_integer(trace, NULL, 0),
-		"bt_ctf_trace_add_environment_field_integer handles a NULL environment field name");
-	ok(!bt_ctf_trace_add_environment_field_integer(trace, "test_env",
-		123456),
-		"Add an integer environment field to a trace instance");
+
+	/* Test bt_ctf_trace_set_environment_field with an integer object */
+	obj = bt_object_integer_create_init(23);
+	assert(obj);
+	ok(bt_ctf_trace_set_environment_field(NULL, "test_env_int_obj", obj),
+		"bt_ctf_trace_set_environment_field handles a NULL trace correctly");
+	ok(bt_ctf_trace_set_environment_field(trace, NULL, obj),
+		"bt_ctf_trace_set_environment_field handles a NULL name correctly");
+	ok(bt_ctf_trace_set_environment_field(trace, "test_env_int_obj", NULL),
+		"bt_ctf_trace_set_environment_field handles a NULL value correctly");
+	ok(!bt_ctf_trace_set_environment_field(trace, "test_env_int_obj", obj),
+		"bt_ctf_trace_set_environment_field succeeds in adding an integer object");
+	BT_OBJECT_PUT(obj);
+
+	/* Test bt_ctf_trace_set_environment_field with a string object */
+	obj = bt_object_string_create_init("the value");
+	assert(obj);
+	ok(!bt_ctf_trace_set_environment_field(trace, "test_env_str_obj", obj),
+		"bt_ctf_trace_set_environment_field succeeds in adding a string object");
+	BT_OBJECT_PUT(obj);
+
+	/* Test bt_ctf_trace_set_environment_field_integer */
+	ok(bt_ctf_trace_set_environment_field_integer(NULL, "test_env_int",
+		-194875),
+		"bt_ctf_trace_set_environment_field_integer handles a NULL trace correctly");
+	ok(bt_ctf_trace_set_environment_field_integer(trace, NULL, -194875),
+		"bt_ctf_trace_set_environment_field_integer handles a NULL name correctly");
+	ok(!bt_ctf_trace_set_environment_field_integer(trace, "test_env_int",
+		-164973),
+		"bt_ctf_trace_set_environment_field_integer succeeds");
+
+	/* Test bt_ctf_trace_set_environment_field_string */
+	ok(bt_ctf_trace_set_environment_field_string(NULL, "test_env_str",
+		"yeah"),
+		"bt_ctf_trace_set_environment_field_string handles a NULL trace correctly");
+	ok(bt_ctf_trace_set_environment_field_string(trace, NULL, "yeah"),
+		"bt_ctf_trace_set_environment_field_string handles a NULL name correctly");
+	ok(bt_ctf_trace_set_environment_field_string(trace, "test_env_str",
+		NULL),
+		"bt_ctf_trace_set_environment_field_string handles a NULL value correctly");
+	ok(!bt_ctf_trace_set_environment_field_string(trace, "test_env_str",
+		"oh yeah"),
+		"bt_ctf_trace_set_environment_field_string succeeds");
 
 	/* Test bt_ctf_trace_get_environment_field_count */
 	ok(bt_ctf_trace_get_environment_field_count(NULL) < 0,
 		"bt_ctf_trace_get_environment_field_count handles a NULL trace correctly");
-	ok(bt_ctf_trace_get_environment_field_count(trace) == 2,
+	ok(bt_ctf_trace_get_environment_field_count(trace) == 5,
 		"bt_ctf_trace_get_environment_field_count returns a correct number of environment fields");
-
-	/* Test bt_ctf_trace_get_environment_field_type */
-	ok(bt_ctf_trace_get_environment_field_type(trace, 2) ==
-		BT_ENVIRONMENT_FIELD_TYPE_UNKNOWN,
-		"bt_ctf_trace_get_environment_field_type handles an invalid index correctly");
-	ok(bt_ctf_trace_get_environment_field_type(NULL, 0) ==
-		BT_ENVIRONMENT_FIELD_TYPE_UNKNOWN,
-		"bt_ctf_trace_get_environment_field_type handles a NULL trace correctly");
-	ok(bt_ctf_trace_get_environment_field_type(trace, 1) ==
-		BT_ENVIRONMENT_FIELD_TYPE_INTEGER,
-		"bt_ctf_trace_get_environment_field_type the correct type of environment field");
 
 	/* Test bt_ctf_trace_get_environment_field_name */
 	ok(bt_ctf_trace_get_environment_field_name(NULL, 0) == NULL,
 		"bt_ctf_trace_get_environment_field_name handles a NULL trace correctly");
 	ok(bt_ctf_trace_get_environment_field_name(trace, -1) == NULL,
-		"bt_ctf_trace_get_environment_field_name handles an invalid index correctly");
+		"bt_ctf_trace_get_environment_field_name handles an invalid index correctly (negative)");
+	ok(bt_ctf_trace_get_environment_field_name(trace, 5) == NULL,
+		"bt_ctf_trace_get_environment_field_name handles an invalid index correctly (too large)");
 	ret_string = bt_ctf_trace_get_environment_field_name(trace, 0);
 	ok(ret_string && !strcmp(ret_string, "host"),
 		"bt_ctf_trace_get_environment_field_name returns a correct field name");
+	ret_string = bt_ctf_trace_get_environment_field_name(trace, 1);
+	ok(ret_string && !strcmp(ret_string, "test_env_int_obj"),
+		"bt_ctf_trace_get_environment_field_name returns a correct field name");
+	ret_string = bt_ctf_trace_get_environment_field_name(trace, 2);
+	ok(ret_string && !strcmp(ret_string, "test_env_str_obj"),
+		"bt_ctf_trace_get_environment_field_name returns a correct field name");
+	ret_string = bt_ctf_trace_get_environment_field_name(trace, 3);
+	ok(ret_string && !strcmp(ret_string, "test_env_int"),
+		"bt_ctf_trace_get_environment_field_name returns a correct field name");
+	ret_string = bt_ctf_trace_get_environment_field_name(trace, 4);
+	ok(ret_string && !strcmp(ret_string, "test_env_str"),
+		"bt_ctf_trace_get_environment_field_name returns a correct field name");
 
-	/* Test bt_ctf_trace_get_environment_field_value_string */
-	ok(bt_ctf_trace_get_environment_field_value_string(NULL, 0) == NULL,
-		"bt_ctf_trace_get_environment_field_value_string handles a NULL trace correctly");
-	ok(bt_ctf_trace_get_environment_field_value_string(trace, -1) == NULL,
-		"bt_ctf_trace_get_environment_field_value_string handles an invalid index correctly");
-	ok(bt_ctf_trace_get_environment_field_value_string(trace, 1) == NULL,
-		"bt_ctf_trace_get_environment_field_value_string validates environment field type");
-	ret_string = bt_ctf_trace_get_environment_field_value_string(trace, 0);
-	ok(ret_string && !strcmp(ret_string, hostname),
-		"bt_ctf_trace_get_environment_field_value_string returns a correct value");
+	/* Test bt_ctf_trace_get_environment_field_value */
+	ok(bt_ctf_trace_get_environment_field_value(NULL, 0) == NULL,
+		"bt_ctf_trace_get_environment_field_value handles a NULL trace correctly");
+	ok(bt_ctf_trace_get_environment_field_value(trace, -1) == NULL,
+		"bt_ctf_trace_get_environment_field_value handles an invalid index correctly (negative)");
+	ok(bt_ctf_trace_get_environment_field_value(trace, 5) == NULL,
+		"bt_ctf_trace_get_environment_field_value handles an invalid index correctly (too large)");
+	obj = bt_ctf_trace_get_environment_field_value(trace, 1);
+	ret = bt_object_integer_get(obj, &ret_int64_t);
+	ok(!ret && ret_int64_t == 23,
+		"bt_ctf_trace_get_environment_field_value succeeds in getting an integer value");
+	BT_OBJECT_PUT(obj);
+	obj = bt_ctf_trace_get_environment_field_value(trace, 2);
+	ret = bt_object_string_get(obj, &ret_string);
+	ok(!ret && ret_string && !strcmp(ret_string, "the value"),
+		"bt_ctf_trace_get_environment_field_value succeeds in getting a string value");
+	BT_OBJECT_PUT(obj);
 
-	/* Test bt_ctf_trace_get_environment_field_value_integer */
-	ok(bt_ctf_trace_get_environment_field_value_integer(NULL, 0, &ret_int64_t) < 0,
-		"bt_ctf_trace_get_environment_field_value_integer handles a NULL trace correctly");
-	ok(bt_ctf_trace_get_environment_field_value_integer(trace, 42, &ret_int64_t) < 0,
-		"bt_ctf_trace_get_environment_field_value_integer handles an invalid index correctly");
-	ok(bt_ctf_trace_get_environment_field_value_integer(trace, 1, NULL) < 0,
-		"bt_ctf_trace_get_environment_field_value_integer handles a NULL value argument correctly");
-	ok(bt_ctf_trace_get_environment_field_value_integer(trace, 0, &ret_int64_t) < 0,
-		"bt_ctf_trace_get_environment_field_value_integer validates environment field type");
-	ok(!bt_ctf_trace_get_environment_field_value_integer(trace, 1, &ret_int64_t),
-		"bt_ctf_trace_get_environment_field_value_integer returns a value");
-	ok(ret_int64_t == 123456,
-		"bt_ctf_trace_get_environment_field_value_integer returned a correct value");
+	/* Test bt_ctf_trace_get_environment_field_value_by_name */
+	ok(!bt_ctf_trace_get_environment_field_value_by_name(NULL,
+		"test_env_str"),
+		"bt_ctf_trace_get_environment_field_value_by_name handles a NULL trace correctly");
+	ok(!bt_ctf_trace_get_environment_field_value_by_name(trace, NULL),
+		"bt_ctf_trace_get_environment_field_value_by_name handles a NULL name correctly");
+	ok(!bt_ctf_trace_get_environment_field_value_by_name(trace, "oh oh"),
+		"bt_ctf_trace_get_environment_field_value_by_name returns NULL or an unknown field name");
+	obj = bt_ctf_trace_get_environment_field_value_by_name(trace,
+		"test_env_str");
+	ret = bt_object_string_get(obj, &ret_string);
+	ok(!ret && ret_string && !strcmp(ret_string, "oh yeah"),
+		"bt_ctf_trace_get_environment_field_value_by_name succeeds in getting an existing field");
+	BT_OBJECT_PUT(obj);
+
+	/* Test environment field replacement */
+	ok(!bt_ctf_trace_set_environment_field_integer(trace, "test_env_int",
+		654321),
+		"bt_ctf_trace_set_environment_field_integer succeeds with an existing name");
+	ok(bt_ctf_trace_get_environment_field_count(trace) == 5,
+		"bt_ctf_trace_set_environment_field_integer with an existing key does not increase the environment size");
+	obj = bt_ctf_trace_get_environment_field_value(trace, 3);
+	ret = bt_object_integer_get(obj, &ret_int64_t);
+	ok(!ret && ret_int64_t == 654321,
+		"bt_ctf_trace_get_environment_field_value successfully replaces an existing field");
+	BT_OBJECT_PUT(obj);
 
 	if (uname(&name)) {
 		perror("uname");

--- a/tests/lib/test_ctf_writer.c
+++ b/tests/lib/test_ctf_writer.c
@@ -1752,6 +1752,22 @@ end:
 	bt_ctf_clock_put(clock);
 }
 
+void append_existing_event_class(struct bt_ctf_stream_class *stream_class)
+{
+	struct bt_ctf_event_class *event_class;
+
+	assert(event_class = bt_ctf_event_class_create("Simple Event"));
+	ok(bt_ctf_stream_class_add_event_class(stream_class, event_class),
+		"two event classes with the same name cannot cohabit within the same stream class");
+	bt_ctf_event_class_put(event_class);
+
+	assert(event_class = bt_ctf_event_class_create("different name, ok"));
+	assert(!bt_ctf_event_class_set_id(event_class, 11));
+	ok(bt_ctf_stream_class_add_event_class(stream_class, event_class),
+		"two event classes with the same ID cannot cohabit within the same stream class");
+	bt_ctf_event_class_put(event_class);
+}
+
 int main(int argc, char **argv)
 {
 	char trace_path[] = "/tmp/ctfwriter_XXXXXX";
@@ -2354,6 +2370,8 @@ int main(int argc, char **argv)
 	packet_resize_test(stream_class, stream1, clock);
 
 	append_complex_event(stream_class, stream1, clock);
+
+	append_existing_event_class(stream_class);
 
 	test_empty_stream(writer);
 


### PR DESCRIPTION
The following patches add a `bt_ctf_attributes_*()` internal API for IR. This uses the new object system (`bt_object`) to keep an array to pairs, each pair containing an attribute name and an attribute value (any object).

This internal API is reused by:

  * environment fields (currently accepts only integer and string values to match CTF v1.8)
  * event attributes (currently accepts only a specific set of attributes to match CTF v1.8)

4fa2d7c also fixes the fact that two event classes could be added to a given stream class with the same name and/or the same ID, which is illegal as per the CTF v1.8.

Tests are added for all this. Valgrind still reports 0 lost bytes for `test_ctf_writer`.