### PR TITLE
IR: add string field utils

### DIFF
--- a/formats/ctf/ir/event-fields.c
+++ b/formats/ctf/ir/event-fields.c
@@ -919,6 +919,33 @@ end:
 	return ret;
 }
 
+int bt_ctf_field_string_append(struct bt_ctf_field *field,
+		const char *value)
+{
+	int ret = 0;
+	struct bt_ctf_field_string *string_field;
+
+	if (!field || !value ||
+		bt_ctf_field_type_get_type_id(field->type) !=
+			CTF_TYPE_STRING) {
+		ret = -1;
+		goto end;
+	}
+
+	string_field = container_of(field, struct bt_ctf_field_string, parent);
+
+	if (string_field->payload) {
+		g_string_append(string_field->payload, value);
+	} else {
+		string_field->payload = g_string_new(value);
+	}
+
+	string_field->parent.payload_set = 1;
+
+end:
+	return ret;
+}
+
 BT_HIDDEN
 int bt_ctf_field_validate(struct bt_ctf_field *field)
 {

--- a/formats/ctf/ir/event-fields.c
+++ b/formats/ctf/ir/event-fields.c
@@ -946,6 +946,45 @@ end:
 	return ret;
 }
 
+int bt_ctf_field_string_append_len(struct bt_ctf_field *field,
+		const char *value, unsigned int length)
+{
+	int i;
+	int ret = 0;
+	unsigned int effective_length = length;
+	struct bt_ctf_field_string *string_field;
+
+	if (!field || !value ||
+		bt_ctf_field_type_get_type_id(field->type) !=
+			CTF_TYPE_STRING) {
+		ret = -1;
+		goto end;
+	}
+
+	string_field = container_of(field, struct bt_ctf_field_string, parent);
+
+	/* make sure no null bytes are appended */
+	for (i = 0; i < length; ++i) {
+		if (value[i] == '\0') {
+			effective_length = i;
+			break;
+		}
+	}
+
+	if (string_field->payload) {
+		g_string_insert_len(string_field->payload, -1, value,
+			effective_length);
+	} else {
+		string_field->payload = g_string_new_len(value,
+			effective_length);
+	}
+
+	string_field->parent.payload_set = 1;
+
+end:
+	return ret;
+}
+
 BT_HIDDEN
 int bt_ctf_field_validate(struct bt_ctf_field *field)
 {

--- a/include/babeltrace/ctf-ir/event-fields.h
+++ b/include/babeltrace/ctf-ir/event-fields.h
@@ -289,6 +289,22 @@ extern int bt_ctf_field_string_set_value(struct bt_ctf_field *string_field,
 		const char *value);
 
 /*
+ * bt_ctf_field_string_append: append a string to a string field's
+ * current value.
+ *
+ * Append a string to the current value of a string field. If the string
+ * field was never set using bt_ctf_field_string_set_value(), it is
+ * first set to an empty string, and then the concatenation happens.
+ *
+ * @param string_field String field instance.
+ * @param value String to append to the current string field's value.
+ *
+ * Returns 0 on success, a negative value on error.
+ */
+extern int bt_ctf_field_string_append(struct bt_ctf_field *string_field,
+		const char *value);
+
+/*
  * bt_ctf_field_get_type: get a field's type
  *
  * @param field Field intance.

--- a/include/babeltrace/ctf-ir/event-fields.h
+++ b/include/babeltrace/ctf-ir/event-fields.h
@@ -305,6 +305,28 @@ extern int bt_ctf_field_string_append(struct bt_ctf_field *string_field,
 		const char *value);
 
 /*
+ * bt_ctf_field_string_append_len: append a string of a given length to
+ * a string field's current value.
+ *
+ * Append a string of a given length to the current value of a string
+ * field. If the string field was never set using
+ * bt_ctf_field_string_set_value(), it is first set to an empty string,
+ * and then the concatenation happens.
+ *
+ * If a null byte is encountered before the given length, only the
+ * substring before the first null byte is appended.
+ *
+ * @param string_field String field instance.
+ * @param value String to append to the current string field's value.
+ * @param length Length of string value to append.
+ *
+ * Returns 0 on success, a negative value on error.
+ */
+extern int bt_ctf_field_string_append_len(
+		struct bt_ctf_field *string_field, const char *value,
+		unsigned int length);
+
+/*
  * bt_ctf_field_get_type: get a field's type
  *
  * @param field Field intance.

--- a/tests/lib/test_ctf_writer.c
+++ b/tests/lib/test_ctf_writer.c
@@ -667,7 +667,9 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 	int64_t int64_value;
 	struct event_class_attrs_counts ;
 	const char *complex_test_event_string = "Complex Test Event";
-	const char *test_string = "Test string";
+	const char *test_string_1 = "Test ";
+	const char *test_string_2 = "string";
+	const char *test_string_cat = "Test string";
 	struct bt_ctf_field_type *uint_35_type =
 		bt_ctf_field_type_integer_create(35);
 	struct bt_ctf_field_type *int_16_type =
@@ -1099,12 +1101,18 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 	ok(!bt_ctf_field_string_get_value(a_string_field),
 		"bt_ctf_field_string_get_value returns NULL on an unset field");
 	bt_ctf_field_string_set_value(a_string_field,
-		test_string);
+		test_string_1);
 	ok(!bt_ctf_field_string_get_value(NULL),
 		"bt_ctf_field_string_get_value correctly handles NULL");
+	ok(bt_ctf_field_string_append(NULL, "yeah"),
+		"bt_ctf_field_string_append correctly handles a NULL string field");
+	ok(bt_ctf_field_string_append(a_string_field, NULL),
+		"bt_ctf_field_string_append correctly handles a NULL string value");
+	ok(!bt_ctf_field_string_append(a_string_field, test_string_2),
+		"bt_ctf_field_string_append succeeds");
 	ret_string = bt_ctf_field_string_get_value(a_string_field);
 	ok(ret_string, "bt_ctf_field_string_get_value returns a string");
-	ok(ret_string ? !strcmp(ret_string, test_string) : 0,
+	ok(ret_string ? !strcmp(ret_string, test_string_cat) : 0,
 		"bt_ctf_field_string_get_value returns a correct value");
 	bt_ctf_field_unsigned_integer_set_value(uint_35_field,
 		SEQUENCE_TEST_LENGTH);

--- a/tests/lib/test_ctf_writer.c
+++ b/tests/lib/test_ctf_writer.c
@@ -668,8 +668,10 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 	struct event_class_attrs_counts ;
 	const char *complex_test_event_string = "Complex Test Event";
 	const char *test_string_1 = "Test ";
-	const char *test_string_2 = "string";
-	const char *test_string_cat = "Test string";
+	const char *test_string_2 = "string ";
+	const char *test_string_3 = "abcdefghi";
+	const char *test_string_4 = "abcd\0efg\0hi";
+	const char *test_string_cat = "Test string abcdeabcd";
 	struct bt_ctf_field_type *uint_35_type =
 		bt_ctf_field_type_integer_create(35);
 	struct bt_ctf_field_type *int_16_type =
@@ -1110,6 +1112,19 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 		"bt_ctf_field_string_append correctly handles a NULL string value");
 	ok(!bt_ctf_field_string_append(a_string_field, test_string_2),
 		"bt_ctf_field_string_append succeeds");
+	ok(bt_ctf_field_string_append_len(NULL, "oh noes", 3),
+		"bt_ctf_field_string_append_len correctly handles a NULL string field");
+	ok(bt_ctf_field_string_append_len(a_string_field, NULL, 3),
+		"bt_ctf_field_string_append_len correctly handles a NULL string value");
+	ok(!bt_ctf_field_string_append_len(a_string_field, test_string_3, 5),
+		"bt_ctf_field_string_append_len succeeds (append 5 characters)");
+	ok(!bt_ctf_field_string_append_len(a_string_field, test_string_4, 10),
+		"bt_ctf_field_string_append_len succeeds (append 4 characters)");
+	ok(!bt_ctf_field_string_append_len(a_string_field, &test_string_4[4], 3),
+		"bt_ctf_field_string_append_len succeeds (append 0 characters)");
+	ok(!bt_ctf_field_string_append_len(a_string_field, test_string_3, 0),
+		"bt_ctf_field_string_append_len succeeds (append 0 characters)");
+
 	ret_string = bt_ctf_field_string_get_value(a_string_field);
 	ok(ret_string, "bt_ctf_field_string_get_value returns a string");
 	ok(ret_string ? !strcmp(ret_string, test_string_cat) : 0,


### PR DESCRIPTION
`bt_ctf_field_string_append()` and `bt_ctf_field_string_append_len()` will be useful in the CTF packet reader, when stopping the decoding process in the middle of a string.