### PR TITLE
Fix: return event timestamp in _timestamp_at_pos

### DIFF
--- a/bindings/python/reader.py
+++ b/bindings/python/reader.py
@@ -207,6 +207,11 @@ class TraceCollection:
         ev_ptr = nbt._bt_ctf_iter_read_event(ctf_it_ptr)
         nbt._bt_ctf_iter_destroy(ctf_it_ptr)
 
+        ev = Event.__new__(Event)
+        ev._e = ev_ptr
+
+        return ev.timestamp
+
     def _events(self, begin_pos_ptr, end_pos_ptr):
         ctf_it_ptr = nbt._bt_ctf_iter_create(self._tc, begin_pos_ptr, end_pos_ptr)
 


### PR DESCRIPTION
The method, called from properties timestamp_begin and timestamp_end, always returned None (implicitly) previously.