### PR TITLE
add bt_ctf_field_variant_get_current_field() and tests

### DIFF
--- a/formats/ctf/ir/event-fields.c
+++ b/formats/ctf/ir/event-fields.c
@@ -652,6 +652,31 @@ end:
 	return new_field;
 }
 
+struct bt_ctf_field *bt_ctf_field_variant_get_current_field(
+		struct bt_ctf_field *variant_field)
+{
+	struct bt_ctf_field *current_field = NULL;
+	struct bt_ctf_field_variant *variant;
+
+	if (!variant_field ||
+		bt_ctf_field_type_get_type_id(variant_field->type) !=
+			CTF_TYPE_VARIANT) {
+		goto end;
+	}
+
+	variant = container_of(variant_field, struct bt_ctf_field_variant,
+		parent);
+
+	if (variant->payload) {
+		current_field = variant->payload;
+		bt_ctf_field_get(current_field);
+		goto end;
+	}
+
+end:
+	return current_field;
+}
+
 struct bt_ctf_field *bt_ctf_field_enumeration_get_container(
 	struct bt_ctf_field *field)
 {

--- a/include/babeltrace/ctf-ir/event-fields.h
+++ b/include/babeltrace/ctf-ir/event-fields.h
@@ -155,6 +155,22 @@ extern struct bt_ctf_field *bt_ctf_field_variant_get_field(
 		struct bt_ctf_field *variant, struct bt_ctf_field *tag);
 
 /*
+ * bt_ctf_field_variant_get_current_field: get the current selected field of a
+ *	variant.
+ *
+ * Return the variant's current selected field. This function, unlike
+ * bt_ctf_field_variant_get_field(), does not create any field; it
+ * returns NULL if there's no current selected field yet.
+ *
+ * @param variant Variant field instance.
+ *
+ * Returns a field instance on success, NULL on error or when there's no
+ * current selected field.
+ */
+extern struct bt_ctf_field *bt_ctf_field_variant_get_current_field(
+		struct bt_ctf_field *variant);
+
+/*
  * bt_ctf_field_enumeration_get_container: get an enumeration field's container.
  *
  * Return the enumeration's underlying container field (an integer).

--- a/tests/lib/test_ctf_writer.c
+++ b/tests/lib/test_ctf_writer.c
@@ -1334,6 +1334,7 @@ void field_copy_tests()
 	struct bt_ctf_field *e = NULL;
 	struct bt_ctf_field *v = NULL;
 	struct bt_ctf_field *v_selected = NULL;
+	struct bt_ctf_field *v_selected_cur = NULL;
 	struct bt_ctf_field *v_selected_0 = NULL;
 	struct bt_ctf_field *v_selected_1 = NULL;
 	struct bt_ctf_field *v_selected_2 = NULL;
@@ -1497,6 +1498,12 @@ void field_copy_tests()
 	/* set v field */
 	v_selected = bt_ctf_field_variant_get_field(v, e);
 	assert(v_selected);
+	ok(!bt_ctf_field_variant_get_current_field(NULL),
+		"bt_ctf_field_variant_get_current_field handles NULL correctly");
+	v_selected_cur = bt_ctf_field_variant_get_current_field(v);
+	ok(v_selected_cur == v_selected,
+		"bt_ctf_field_variant_get_current_field returns the current field");
+	bt_ctf_field_put(v_selected_cur);
 
 	/* set selected v field */
 	ret = bt_ctf_field_sequence_set_length(v_selected, len);


### PR DESCRIPTION
`bt_ctf_field_variant_get_current_field()` returns the current selected field of a variant field. With this function, the user does not need to find the actual enumeration field used as the variant's tag and pass it to `bt_ctf_field_variant_get_field()` to retrieve the current selected field.

Another option would be to pass `NULL` to the tag parameter of `bt_ctf_field_variant_get_field()`, but I find this new function name more explicit than juggling with `NULL` params.