### PR TITLE
CTF IR: consolidate reference counting functions

### DIFF
--- a/formats/ctf/ir/event-types.c
+++ b/formats/ctf/ir/event-types.c
@@ -29,6 +29,8 @@
 #include <babeltrace/ctf-writer/event-types.h>
 #include <babeltrace/ctf-ir/event-types-internal.h>
 #include <babeltrace/ctf-ir/utils.h>
+#include <babeltrace/ctf-ir/ref.h>
+#include <babeltrace/ctf-ir/common-internal.h>
 #include <babeltrace/ctf-ir/clock.h>
 #include <babeltrace/ctf-writer/writer-internal.h>
 #include <babeltrace/compiler.h>
@@ -52,26 +54,26 @@ struct range_overlap_query {
 };
 
 static
-void bt_ctf_field_type_destroy(struct bt_ctf_ref *);
+void bt_ctf_field_type_destroy(struct bt_ref *);
 static
-void bt_ctf_field_type_integer_destroy(struct bt_ctf_ref *);
+void bt_ctf_field_type_integer_destroy(struct bt_ctf_field_type *);
 static
-void bt_ctf_field_type_enumeration_destroy(struct bt_ctf_ref *);
+void bt_ctf_field_type_enumeration_destroy(struct bt_ctf_field_type *);
 static
-void bt_ctf_field_type_floating_point_destroy(struct bt_ctf_ref *);
+void bt_ctf_field_type_floating_point_destroy(struct bt_ctf_field_type *);
 static
-void bt_ctf_field_type_structure_destroy(struct bt_ctf_ref *);
+void bt_ctf_field_type_structure_destroy(struct bt_ctf_field_type *);
 static
-void bt_ctf_field_type_variant_destroy(struct bt_ctf_ref *);
+void bt_ctf_field_type_variant_destroy(struct bt_ctf_field_type *);
 static
-void bt_ctf_field_type_array_destroy(struct bt_ctf_ref *);
+void bt_ctf_field_type_array_destroy(struct bt_ctf_field_type *);
 static
-void bt_ctf_field_type_sequence_destroy(struct bt_ctf_ref *);
+void bt_ctf_field_type_sequence_destroy(struct bt_ctf_field_type *);
 static
-void bt_ctf_field_type_string_destroy(struct bt_ctf_ref *);
+void bt_ctf_field_type_string_destroy(struct bt_ctf_field_type *);
 
 static
-void (* const type_destroy_funcs[])(struct bt_ctf_ref *) = {
+void (* const type_destroy_funcs[])(struct bt_ctf_field_type *) = {
 	[CTF_TYPE_INTEGER] = bt_ctf_field_type_integer_destroy,
 	[CTF_TYPE_ENUM] =
 		bt_ctf_field_type_enumeration_destroy,
@@ -299,7 +301,7 @@ void bt_ctf_field_type_init(struct bt_ctf_field_type *type)
 	assert(type && (type_id > CTF_TYPE_UNKNOWN) &&
 		(type_id < NR_CTF_TYPES));
 
-	bt_ctf_ref_init(&type->ref_count);
+	bt_ctf_base_init(type, bt_ctf_field_type_destroy);
 	type->freeze = type_freeze_funcs[type_id];
 	type->serialize = type_serialize_funcs[type_id];
 	ret = bt_ctf_field_type_set_byte_order(type, BT_CTF_BYTE_ORDER_NATIVE);
@@ -342,23 +344,25 @@ end:
 }
 
 static
-void bt_ctf_field_type_destroy(struct bt_ctf_ref *ref)
+void bt_ctf_field_type_destroy(struct bt_ref *ref)
 {
 	struct bt_ctf_field_type *type;
+	struct bt_ctf_base *base;
 	enum ctf_type_id type_id;
 
 	if (!ref) {
 		return;
 	}
 
-	type = container_of(ref, struct bt_ctf_field_type, ref_count);
+	base = container_of(ref, struct bt_ctf_base, ref_count);
+	type = container_of(base, struct bt_ctf_field_type, base);
 	type_id = type->declaration->id;
 	if (type_id <= CTF_TYPE_UNKNOWN ||
 		type_id >= NR_CTF_TYPES) {
 		return;
 	}
 
-	type_destroy_funcs[type_id](ref);
+	type_destroy_funcs[type_id](type);
 }
 
 BT_HIDDEN
@@ -1910,20 +1914,12 @@ enum ctf_type_id bt_ctf_field_type_get_type_id(
 
 void bt_ctf_field_type_get(struct bt_ctf_field_type *type)
 {
-	if (!type) {
-		return;
-	}
-
-	bt_ctf_ref_get(&type->ref_count);
+	bt_ctf_get(type);
 }
 
 void bt_ctf_field_type_put(struct bt_ctf_field_type *type)
 {
-	if (!type) {
-		return;
-	}
-
-	bt_ctf_ref_put(&type->ref_count, bt_ctf_field_type_destroy);
+	bt_ctf_put(type);
 }
 
 BT_HIDDEN
@@ -2292,17 +2288,15 @@ end:
 }
 
 static
-void bt_ctf_field_type_integer_destroy(struct bt_ctf_ref *ref)
+void bt_ctf_field_type_integer_destroy(struct bt_ctf_field_type *type)
 {
-	struct bt_ctf_field_type_integer *integer;
+	struct bt_ctf_field_type_integer *integer =
+		(struct bt_ctf_field_type_integer *) type;
 
-	if (!ref) {
+	if (!type) {
 		return;
 	}
 
-	integer = container_of(
-		container_of(ref, struct bt_ctf_field_type, ref_count),
-		struct bt_ctf_field_type_integer, parent);
 	if (integer->mapped_clock) {
 		bt_ctf_clock_put(integer->mapped_clock);
 	}
@@ -2310,66 +2304,58 @@ void bt_ctf_field_type_integer_destroy(struct bt_ctf_ref *ref)
 }
 
 static
-void bt_ctf_field_type_enumeration_destroy(struct bt_ctf_ref *ref)
+void bt_ctf_field_type_enumeration_destroy(struct bt_ctf_field_type *type)
 {
-	struct bt_ctf_field_type_enumeration *enumeration;
+	struct bt_ctf_field_type_enumeration *enumeration =
+		(struct bt_ctf_field_type_enumeration *) type;
 
-	if (!ref) {
+	if (!type) {
 		return;
 	}
 
-	enumeration = container_of(
-		container_of(ref, struct bt_ctf_field_type, ref_count),
-		struct bt_ctf_field_type_enumeration, parent);
 	g_ptr_array_free(enumeration->entries, TRUE);
 	bt_ctf_field_type_put(enumeration->container);
 	g_free(enumeration);
 }
 
 static
-void bt_ctf_field_type_floating_point_destroy(struct bt_ctf_ref *ref)
+void bt_ctf_field_type_floating_point_destroy(struct bt_ctf_field_type *type)
 {
-	struct bt_ctf_field_type_floating_point *floating_point;
+	struct bt_ctf_field_type_floating_point *floating_point =
+		(struct bt_ctf_field_type_floating_point *) type;
 
-	if (!ref) {
+	if (!type) {
 		return;
 	}
 
-	floating_point = container_of(
-		container_of(ref, struct bt_ctf_field_type, ref_count),
-		struct bt_ctf_field_type_floating_point, parent);
 	g_free(floating_point);
 }
 
 static
-void bt_ctf_field_type_structure_destroy(struct bt_ctf_ref *ref)
+void bt_ctf_field_type_structure_destroy(struct bt_ctf_field_type *type)
 {
-	struct bt_ctf_field_type_structure *structure;
+	struct bt_ctf_field_type_structure *structure =
+		(struct bt_ctf_field_type_structure *) type;
 
-	if (!ref) {
+	if (!type) {
 		return;
 	}
 
-	structure = container_of(
-		container_of(ref, struct bt_ctf_field_type, ref_count),
-		struct bt_ctf_field_type_structure, parent);
 	g_ptr_array_free(structure->fields, TRUE);
 	g_hash_table_destroy(structure->field_name_to_index);
 	g_free(structure);
 }
 
 static
-void bt_ctf_field_type_variant_destroy(struct bt_ctf_ref *ref)
+void bt_ctf_field_type_variant_destroy(struct bt_ctf_field_type *type)
 {
-	struct bt_ctf_field_type_variant *variant;
+	struct bt_ctf_field_type_variant *variant =
+		(struct bt_ctf_field_type_variant *) type;
 
-	if (!ref) {
+	if (!type) {
 		return;
 	}
 
-	variant = container_of(
-		container_of(ref, struct bt_ctf_field_type, ref_count),
-		struct bt_ctf_field_type_variant, parent);
 	g_ptr_array_free(variant->fields, TRUE);
 	g_hash_table_destroy(variant->field_name_to_index);
 	g_string_free(variant->tag_name, TRUE);
@@ -2379,33 +2365,29 @@ void bt_ctf_field_type_variant_destroy(struct bt_ctf_ref *ref)
 }
 
 static
-void bt_ctf_field_type_array_destroy(struct bt_ctf_ref *ref)
+void bt_ctf_field_type_array_destroy(struct bt_ctf_field_type *type)
 {
-	struct bt_ctf_field_type_array *array;
+	struct bt_ctf_field_type_array *array =
+		(struct bt_ctf_field_type_array *) type;
 
-	if (!ref) {
+	if (!type) {
 		return;
 	}
 
-	array = container_of(
-		container_of(ref, struct bt_ctf_field_type, ref_count),
-		struct bt_ctf_field_type_array, parent);
 	bt_ctf_field_type_put(array->element_type);
 	g_free(array);
 }
 
 static
-void bt_ctf_field_type_sequence_destroy(struct bt_ctf_ref *ref)
+void bt_ctf_field_type_sequence_destroy(struct bt_ctf_field_type *type)
 {
-	struct bt_ctf_field_type_sequence *sequence;
+	struct bt_ctf_field_type_sequence *sequence =
+		(struct bt_ctf_field_type_sequence *) type;
 
-	if (!ref) {
+	if (!type) {
 		return;
 	}
 
-	sequence = container_of(
-		container_of(ref, struct bt_ctf_field_type, ref_count),
-		struct bt_ctf_field_type_sequence, parent);
 	bt_ctf_field_type_put(sequence->element_type);
 	g_string_free(sequence->length_field_name, TRUE);
 	bt_ctf_field_path_destroy(sequence->length_field_path);
@@ -2413,17 +2395,15 @@ void bt_ctf_field_type_sequence_destroy(struct bt_ctf_ref *ref)
 }
 
 static
-void bt_ctf_field_type_string_destroy(struct bt_ctf_ref *ref)
+void bt_ctf_field_type_string_destroy(struct bt_ctf_field_type *type)
 {
-	struct bt_ctf_field_type_string *string;
+	struct bt_ctf_field_type_string *string =
+		(struct bt_ctf_field_type_string *) type;
 
-	if (!ref) {
+	if (!type) {
 		return;
 	}
 
-	string = container_of(
-		container_of(ref, struct bt_ctf_field_type, ref_count),
-		struct bt_ctf_field_type_string, parent);
 	g_free(string);
 }
 

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -27,6 +27,7 @@ babeltracectfirinclude_HEADERS = \
 	babeltrace/ctf-ir/event-fields.h \
 	babeltrace/ctf-ir/event-types.h \
 	babeltrace/ctf-ir/event.h \
+	babeltrace/ctf-ir/ref.h \
 	babeltrace/ctf-ir/stream.h \
 	babeltrace/ctf-ir/stream-class.h \
 	babeltrace/ctf-ir/trace.h \
@@ -43,6 +44,7 @@ noinst_HEADERS = \
 	babeltrace/iterator-internal.h \
 	babeltrace/trace-collection.h \
 	babeltrace/prio_heap.h \
+	babeltrace/ref-internal.h \
 	babeltrace/types.h \
 	babeltrace/ctf-ir/metadata.h \
 	babeltrace/ctf/events-internal.h \
@@ -51,9 +53,9 @@ noinst_HEADERS = \
 	babeltrace/ctf/types.h \
 	babeltrace/ctf/callbacks-internal.h \
 	babeltrace/ctf/ctf-index.h \
-	babeltrace/ctf-writer/ref-internal.h \
 	babeltrace/ctf-writer/writer-internal.h \
 	babeltrace/ctf-ir/attributes-internal.h \
+	babeltrace/ctf-ir/common-internal.h \
 	babeltrace/ctf-ir/event-types-internal.h \
 	babeltrace/ctf-ir/event-fields-internal.h \
 	babeltrace/ctf-ir/event-internal.h \

--- a/include/babeltrace/ctf-ir/clock-internal.h
+++ b/include/babeltrace/ctf-ir/clock-internal.h
@@ -27,15 +27,15 @@
  * SOFTWARE.
  */
 
-#include <babeltrace/ctf-writer/ref-internal.h>
 #include <babeltrace/ctf-writer/clock.h>
 #include <babeltrace/ctf-ir/trace-internal.h>
+#include <babeltrace/ctf-ir/common-internal.h>
 #include <babeltrace/babeltrace-internal.h>
 #include <glib.h>
 #include <babeltrace/compat/uuid.h>
 
 struct bt_ctf_clock {
-	struct bt_ctf_ref ref_count;
+	struct bt_ctf_base base;
 	GString *name;
 	GString *description;
 	uint64_t frequency;

--- a/include/babeltrace/ctf-ir/clock.h
+++ b/include/babeltrace/ctf-ir/clock.h
@@ -258,6 +258,8 @@ extern int bt_ctf_clock_set_time(struct bt_ctf_clock *clock,
  * bt_ctf_clock_get and bt_ctf_clock_put: increment and decrement the
  * refcount of the clock
  *
+ * You may also use bt_ctf_get() and bt_ctf_put() with clock objects.
+ *
  * These functions ensure that the clock won't be destroyed when it
  * is in use. The same number of get and put (plus one extra put to
  * release the initial reference done at creation) has to be done to

--- a/include/babeltrace/ctf-ir/common-internal.h
+++ b/include/babeltrace/ctf-ir/common-internal.h
@@ -1,12 +1,11 @@
-#ifndef BABELTRACE_CTF_WRITER_REF_INTERNAL_H
-#define BABELTRACE_CTF_WRITER_REF_INTERNAL_H
+#ifndef BABELTRACE_CTF_IR_COMMON_INTERNAL_H
+#define BABELTRACE_CTF_IR_COMMON_INTERNAL_H
 
 /*
- * BabelTrace - CTF Writer: Reference count
+ * Babeltrace - CTF IR: common data structures
  *
- * Copyright 2013, 2014 Jérémie Galarneau <jeremie.galarneau@efficios.com>
- *
- * Author: Jérémie Galarneau <jeremie.galarneau@efficios.com>
+ * Copyright (c) 2015 EfficiOS Inc. and Linux Foundation
+ * Copyright (c) 2015 Philippe Proulx <pproulx@efficios.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,35 +26,19 @@
  * SOFTWARE.
  */
 
-#include <assert.h>
+#include <babeltrace/ref-internal.h>
 
-struct bt_ctf_ref {
-	long refcount;
+/* this must be the base class of _all_ CTF IR classes */
+struct bt_ctf_base {
+	struct bt_ref ref_count;
 };
 
 static inline
-void bt_ctf_ref_init(struct bt_ctf_ref *ref)
+void bt_ctf_base_init(void *obj, bt_ref_release_func_t release_func)
 {
-	assert(ref);
-	ref->refcount = 1;
+	struct bt_ctf_base *base = obj;
+
+	bt_ref_init(&base->ref_count, release_func);
 }
 
-static inline
-void bt_ctf_ref_get(struct bt_ctf_ref *ref)
-{
-	assert(ref);
-	ref->refcount++;
-}
-
-static inline
-void bt_ctf_ref_put(struct bt_ctf_ref *ref,
-		void (*release)(struct bt_ctf_ref *))
-{
-	assert(ref);
-	assert(release);
-	if ((--ref->refcount) == 0) {
-		release(ref);
-	}
-}
-
-#endif /* BABELTRACE_CTF_WRITER_REF_INTERNAL_H */
+#endif /* BABELTRACE_CTF_IR_COMMON_INTERNAL_H */

--- a/include/babeltrace/ctf-ir/event-fields-internal.h
+++ b/include/babeltrace/ctf-ir/event-fields-internal.h
@@ -27,14 +27,14 @@
  * SOFTWARE.
  */
 
-#include <babeltrace/ctf-writer/ref-internal.h>
 #include <babeltrace/ctf-writer/event-fields.h>
+#include <babeltrace/ctf-ir/common-internal.h>
 #include <babeltrace/babeltrace-internal.h>
 #include <babeltrace/ctf/types.h>
 #include <glib.h>
 
 struct bt_ctf_field {
-	struct bt_ctf_ref ref_count;
+	struct bt_ctf_base base;
 	struct bt_ctf_field_type *type;
 	int payload_set;
 };

--- a/include/babeltrace/ctf-ir/event-fields.h
+++ b/include/babeltrace/ctf-ir/event-fields.h
@@ -370,6 +370,8 @@ extern struct bt_ctf_field *bt_ctf_field_copy(struct bt_ctf_field *field);
  * bt_ctf_field_get and bt_ctf_field_put: increment and decrement the
  * field's reference count.
  *
+ * You may also use bt_ctf_get() and bt_ctf_put() with field objects.
+ *
  * These functions ensure that the field won't be destroyed when it
  * is in use. The same number of get and put (plus one extra put to
  * release the initial reference done at creation) have to be done to

--- a/include/babeltrace/ctf-ir/event-internal.h
+++ b/include/babeltrace/ctf-ir/event-internal.h
@@ -27,7 +27,6 @@
  * SOFTWARE.
  */
 
-#include <babeltrace/ctf-writer/ref-internal.h>
 #include <babeltrace/ctf-writer/event-types.h>
 #include <babeltrace/ctf-writer/event-fields.h>
 #include <babeltrace/babeltrace-internal.h>
@@ -35,13 +34,14 @@
 #include <babeltrace/ctf/types.h>
 #include <babeltrace/ctf-ir/stream-class.h>
 #include <babeltrace/ctf-ir/stream.h>
+#include <babeltrace/ctf-ir/common-internal.h>
 #include <glib.h>
 
 #define BT_CTF_EVENT_CLASS_ATTR_ID_INDEX	0
 #define BT_CTF_EVENT_CLASS_ATTR_NAME_INDEX	1
 
 struct bt_ctf_event_class {
-	struct bt_ctf_ref ref_count;
+	struct bt_ctf_base base;
 	struct bt_object *attributes;
 	/*
 	 * Weak reference; an event class does not have ownership of a
@@ -56,7 +56,7 @@ struct bt_ctf_event_class {
 };
 
 struct bt_ctf_event {
-	struct bt_ctf_ref ref_count;
+	struct bt_ctf_base base;
 	struct bt_ctf_event_class *event_class;
 	/* Weak reference; an event does not have ownership of a stream */
 	struct bt_ctf_stream *stream;

--- a/include/babeltrace/ctf-ir/event-types-internal.h
+++ b/include/babeltrace/ctf-ir/event-types-internal.h
@@ -28,10 +28,10 @@
  */
 
 #include <babeltrace/ctf-writer/event-types.h>
-#include <babeltrace/ctf-writer/ref-internal.h>
 #include <babeltrace/ctf-writer/event-fields.h>
 #include <babeltrace/ctf-writer/writer.h>
 #include <babeltrace/ctf-ir/trace-internal.h>
+#include <babeltrace/ctf-ir/common-internal.h>
 #include <babeltrace/babeltrace-internal.h>
 #include <babeltrace/types.h>
 #include <babeltrace/ctf/events.h>
@@ -62,7 +62,7 @@ struct bt_ctf_field_path {
 };
 
 struct bt_ctf_field_type {
-	struct bt_ctf_ref ref_count;
+	struct bt_ctf_base base;
 	struct bt_declaration *declaration;
 	type_freeze_func freeze;
 	type_serialize_func serialize;

--- a/include/babeltrace/ctf-ir/event-types.h
+++ b/include/babeltrace/ctf-ir/event-types.h
@@ -755,6 +755,8 @@ extern enum ctf_type_id bt_ctf_field_type_get_type_id(
  * bt_ctf_field_type_get and bt_ctf_field_type_put: increment and decrement
  * the field type's reference count.
  *
+ * You may also use bt_ctf_get() and bt_ctf_put() with field type objects.
+ *
  * These functions ensure that the field type won't be destroyed while it
  * is in use. The same number of get and put (plus one extra put to
  * release the initial reference done at creation) have to be done to

--- a/include/babeltrace/ctf-ir/event.h
+++ b/include/babeltrace/ctf-ir/event.h
@@ -307,6 +307,8 @@ extern int bt_ctf_event_class_set_context_type(
  * bt_ctf_event_class_get and bt_ctf_event_class_put: increment and decrement
  * the event class' reference count.
  *
+ * You may also use bt_ctf_get() and bt_ctf_put() with event class objects.
+ *
  * These functions ensure that the event class won't be destroyed while it
  * is in use. The same number of get and put (plus one extra put to
  * release the initial reference done at creation) have to be done to
@@ -511,6 +513,8 @@ extern struct bt_ctf_event *bt_ctf_event_copy(struct bt_ctf_event *event);
 /*
  * bt_ctf_event_get and bt_ctf_event_put: increment and decrement
  * the event's reference count.
+ *
+ * You may also use bt_ctf_get() and bt_ctf_put() with event objects.
  *
  * These functions ensure that the event won't be destroyed while it
  * is in use. The same number of get and put (plus one extra put to

--- a/include/babeltrace/ctf-ir/ref.h
+++ b/include/babeltrace/ctf-ir/ref.h
@@ -1,0 +1,98 @@
+#ifndef BABELTRACE_CTF_IR_REF_H
+#define BABELTRACE_CTF_IR_REF_H
+
+/*
+ * BabelTrace - CTF IR: common reference counting
+ *
+ * Copyright (c) 2015 EfficiOS Inc. and Linux Foundation
+ * Copyright (c) 2015 Philippe Proulx <pproulx@efficios.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <assert.h>
+#include <babeltrace/ref-internal.h>
+#include <babeltrace/ctf-ir/common-internal.h>
+
+/*
+ * BT_CTF_PUT: calls bt_ctf_put() with a variable, then sets this
+ * 	variable to NULL.
+ *
+ * A common action with CTF IR objects is to create or get one, do
+ * something with it, and then put it. To avoid putting it a second time
+ * later (if an error occurs, for example), the variable is often reset
+ * to NULL after putting the object it points to. Since this is so
+ * common, you can use the BT_CTF_PUT() macro, which does just that.
+ *
+ * It is safe to call this function with a NULL object.
+ *
+ * @param obj CTF IR object.
+ */
+#define BT_CTF_PUT(_obj)		\
+	do {				\
+		bt_ctf_put(_obj);	\
+		(_obj) = NULL;		\
+	} while (0)
+
+/*
+ * bt_ctf_get: increments the reference count of a CTF IR object.
+ *
+ * The same number of bt_ctf_get() and bt_ctf_put() (plus one extra
+ * bt_ctf_put() to release the initial reference done at creation) have
+ * to be done to destroy a CTF IR object.
+ *
+ * It is safe to call this function with a NULL object.
+ *
+ * @param obj CTF IR object.
+ */
+static inline
+void bt_ctf_get(void *obj)
+{
+	if (obj) {
+		struct bt_ctf_base *base = obj;
+
+		bt_ref_get(&base->ref_count);
+	}
+}
+
+/*
+ * bt_ctf_put: decrements the reference count of a CTF IR object.
+ *
+ * The same number of bt_ctf_get() and bt_ctf_put() (plus one extra
+ * bt_ctf_put() to release the initial reference done at creation) have
+ * to be done to destroy a CTF IR object.
+ *
+ * When the object's reference count is decremented to 0 by a call to
+ * bt_ctf_put(), the object is freed.
+ *
+ * It is safe to call this function with a NULL object.
+ *
+ * @param obj CTF IR object.
+ */
+static inline
+void bt_ctf_put(void *obj)
+{
+	if (obj) {
+		struct bt_ctf_base *base = obj;
+
+		bt_ref_put(&base->ref_count);
+	}
+}
+
+#endif /* BABELTRACE_CTF_IR_REF_H */

--- a/include/babeltrace/ctf-ir/stream-class-internal.h
+++ b/include/babeltrace/ctf-ir/stream-class-internal.h
@@ -27,17 +27,17 @@
  * SOFTWARE.
  */
 
-#include <babeltrace/ctf-writer/ref-internal.h>
 #include <babeltrace/ctf-writer/clock.h>
 #include <babeltrace/ctf-writer/event-fields.h>
 #include <babeltrace/ctf-writer/event-types.h>
 #include <babeltrace/ctf-ir/trace.h>
+#include <babeltrace/ctf-ir/common-internal.h>
 #include <babeltrace/babeltrace-internal.h>
 #include <babeltrace/ctf/types.h>
 #include <glib.h>
 
 struct bt_ctf_stream_class {
-	struct bt_ctf_ref ref_count;
+	struct bt_ctf_base base;
 	GString *name;
 	struct bt_ctf_clock *clock;
 	GPtrArray *event_classes; /* Array of pointers to bt_ctf_event_class */

--- a/include/babeltrace/ctf-ir/stream-class.h
+++ b/include/babeltrace/ctf-ir/stream-class.h
@@ -290,6 +290,8 @@ extern int bt_ctf_stream_class_set_event_context_type(
  * bt_ctf_stream_class_get and bt_ctf_stream_class_put: increment and
  * decrement the stream class' reference count.
  *
+ * You may also use bt_ctf_get() and bt_ctf_put() with stream class objects.
+ *
  * These functions ensure that the stream class won't be destroyed while it
  * is in use. The same number of get and put (plus one extra put to
  * release the initial reference done at creation) have to be done to

--- a/include/babeltrace/ctf-ir/stream-internal.h
+++ b/include/babeltrace/ctf-ir/stream-internal.h
@@ -28,7 +28,7 @@
  */
 
 #include <babeltrace/ctf-ir/stream.h>
-#include <babeltrace/ctf-writer/ref-internal.h>
+#include <babeltrace/ctf-ir/common-internal.h>
 #include <babeltrace/ctf-writer/clock.h>
 #include <babeltrace/ctf-writer/event-fields.h>
 #include <babeltrace/ctf-writer/event-types.h>
@@ -37,7 +37,7 @@
 #include <glib.h>
 
 struct bt_ctf_stream {
-	struct bt_ctf_ref ref_count;
+	struct bt_ctf_base base;
 	/* Trace owning this stream. A stream does not own a trace. */
 	struct bt_ctf_trace *trace;
 	uint32_t id;

--- a/include/babeltrace/ctf-ir/stream.h
+++ b/include/babeltrace/ctf-ir/stream.h
@@ -219,6 +219,8 @@ extern int bt_ctf_stream_flush(struct bt_ctf_stream *stream);
  * bt_ctf_stream_get and bt_ctf_stream_put: increment and decrement the
  * stream's reference count.
  *
+ * You may also use bt_ctf_get() and bt_ctf_put() with stream objects.
+ *
  * These functions ensure that the stream won't be destroyed while it
  * is in use. The same number of get and put (plus one extra put to
  * release the initial reference done at creation) have to be done to

--- a/include/babeltrace/ctf-ir/trace-internal.h
+++ b/include/babeltrace/ctf-ir/trace-internal.h
@@ -27,10 +27,10 @@
  * SOFTWARE.
  */
 
-#include <babeltrace/ctf-writer/ref-internal.h>
 #include <babeltrace/ctf-ir/trace.h>
 #include <babeltrace/ctf-ir/event-types.h>
 #include <babeltrace/ctf-ir/event-fields.h>
+#include <babeltrace/ctf-ir/common-internal.h>
 #include <babeltrace/babeltrace-internal.h>
 #include <babeltrace/objects.h>
 #include <glib.h>
@@ -48,7 +48,7 @@ enum field_type_alias {
 };
 
 struct bt_ctf_trace {
-	struct bt_ctf_ref ref_count;
+	struct bt_ctf_base base;
 	int frozen;
 	uuid_t uuid;
 	int byte_order; /* A value defined in Babeltrace's "endian.h" */

--- a/include/babeltrace/ctf-ir/trace.h
+++ b/include/babeltrace/ctf-ir/trace.h
@@ -346,6 +346,8 @@ extern int bt_ctf_trace_set_packet_header_type(struct bt_ctf_trace *trace,
  * bt_ctf_trace_get and bt_ctf_trace_put: increment and decrement the
  * trace's reference count.
  *
+ * You may also use bt_ctf_get() and bt_ctf_put() with trace objects.
+ *
  * These functions ensure that the trace won't be destroyed while it
  * is in use. The same number of get and put (plus one extra put to
  * release the initial reference done at creation) have to be done to

--- a/include/babeltrace/ctf-writer/writer.h
+++ b/include/babeltrace/ctf-writer/writer.h
@@ -153,6 +153,8 @@ extern int bt_ctf_writer_set_byte_order(struct bt_ctf_writer *writer,
  * bt_ctf_writer_get and bt_ctf_writer_put: increment and decrement the
  * writer's reference count.
  *
+ * You may also use bt_ctf_get() and bt_ctf_put() with writer objects.
+ *
  * These functions ensure that the writer won't be destroyed while it
  * is in use. The same number of get and put (plus one extra put to
  * release the initial reference done at creation) have to be done to

--- a/tests/lib/test_ctf_writer.c
+++ b/tests/lib/test_ctf_writer.c
@@ -27,6 +27,7 @@
 #include <babeltrace/ctf-writer/event-types.h>
 #include <babeltrace/ctf-writer/event-fields.h>
 #include <babeltrace/ctf-ir/stream-class.h>
+#include <babeltrace/ctf-ir/ref.h>
 #include <babeltrace/ctf/events.h>
 #include <babeltrace/objects.h>
 #include <unistd.h>
@@ -298,8 +299,8 @@ void event_copy_tests(struct bt_ctf_event *event)
 	copy_event_class = bt_ctf_event_get_class(copy);
 	ok(orig_event_class == copy_event_class,
 		"original and copied events share the same event class pointer");
-	bt_ctf_event_class_put(orig_event_class);
-	bt_ctf_event_class_put(copy_event_class);
+	bt_ctf_put(orig_event_class);
+	bt_ctf_put(copy_event_class);
 
 	/* validate stream */
 	orig_stream = bt_ctf_event_get_stream(event);
@@ -311,8 +312,8 @@ void event_copy_tests(struct bt_ctf_event *event)
 		ok(orig_stream == copy_stream,
 			"original and copied events share the same stream pointer");
 	}
-	bt_ctf_stream_put(orig_stream);
-	bt_ctf_stream_put(copy_stream);
+	bt_ctf_put(orig_stream);
+	bt_ctf_put(copy_stream);
 
 	/* header */
 	orig_field = bt_ctf_event_get_header(event);
@@ -325,8 +326,8 @@ void event_copy_tests(struct bt_ctf_event *event)
 			"original and copied events headers are different pointers");
 	}
 
-	bt_ctf_field_put(orig_field);
-	bt_ctf_field_put(copy_field);
+	bt_ctf_put(orig_field);
+	bt_ctf_put(copy_field);
 
 	/* context */
 	orig_field = bt_ctf_event_get_event_context(event);
@@ -339,8 +340,8 @@ void event_copy_tests(struct bt_ctf_event *event)
 			"original and copied events contexts are different pointers");
 	}
 
-	bt_ctf_field_put(orig_field);
-	bt_ctf_field_put(copy_field);
+	bt_ctf_put(orig_field);
+	bt_ctf_put(copy_field);
 
 	/* payload */
 	orig_field = bt_ctf_event_get_payload_field(event);
@@ -353,10 +354,10 @@ void event_copy_tests(struct bt_ctf_event *event)
 			"original and copied events payloads are different pointers");
 	}
 
-	bt_ctf_field_put(orig_field);
-	bt_ctf_field_put(copy_field);
+	bt_ctf_put(orig_field);
+	bt_ctf_put(copy_field);
 
-	bt_ctf_event_put(copy);
+	bt_ctf_put(copy);
 }
 
 void append_simple_event(struct bt_ctf_stream_class *stream_class,
@@ -411,7 +412,7 @@ void append_simple_event(struct bt_ctf_stream_class *stream_class,
 	ok(!bt_ctf_field_type_enumeration_get_container_type(NULL), "bt_ctf_field_type_enumeration_get_container_type handles NULL correctly");
 	ok(!bt_ctf_field_type_enumeration_create(enum_type),
 		"bt_ctf_field_enumeration_type_create rejects non-integer container field types");
-	bt_ctf_field_type_put(returned_type);
+	bt_ctf_put(returned_type);
 
 	bt_ctf_field_type_set_alignment(float_type, 32);
 	ok(bt_ctf_field_type_get_alignment(NULL) < 0,
@@ -559,7 +560,7 @@ void append_simple_event(struct bt_ctf_stream_class *stream_class,
 	returned_type = bt_ctf_event_class_get_context_type(simple_event_class);
 	ok(returned_type == event_context_type,
 		"bt_ctf_event_class_get_context_type returns the appropriate type");
-	bt_ctf_field_type_put(returned_type);
+	bt_ctf_put(returned_type);
 
 	bt_ctf_stream_class_add_event_class(stream_class, simple_event_class);
 
@@ -574,7 +575,7 @@ void append_simple_event(struct bt_ctf_stream_class *stream_class,
 	ret_event_class = bt_ctf_stream_class_get_event_class(stream_class, 0);
 	ok(ret_event_class == simple_event_class,
 		"bt_ctf_stream_class_get_event_class returns the correct event class");
-	bt_ctf_event_class_put(ret_event_class);
+	bt_ctf_put(ret_event_class);
 	ok(!bt_ctf_stream_class_get_event_class_by_id(NULL, 0),
 		"bt_ctf_stream_class_get_event_class_by_id handles NULL correctly");
 	ok(!bt_ctf_stream_class_get_event_class_by_id(stream_class, 2),
@@ -583,7 +584,7 @@ void append_simple_event(struct bt_ctf_stream_class *stream_class,
 		bt_ctf_stream_class_get_event_class_by_id(stream_class, 13);
 	ok(ret_event_class == simple_event_class,
 		"bt_ctf_stream_class_get_event_class_by_id returns a correct event class");
-	bt_ctf_event_class_put(ret_event_class);
+	bt_ctf_put(ret_event_class);
 
 	ok(bt_ctf_stream_class_get_event_class_by_name(NULL, "some event name") == NULL,
 		"bt_ctf_stream_class_get_event_class_by_name handles a NULL stream class correctly");
@@ -594,7 +595,7 @@ void append_simple_event(struct bt_ctf_stream_class *stream_class,
 	ret_event_class = bt_ctf_stream_class_get_event_class_by_name(stream_class, "Simple Event");
 	ok(ret_event_class == simple_event_class,
 		"bt_ctf_stream_class_get_event_class_by_name returns a correct event class");
-	bt_ctf_event_class_put(ret_event_class);
+	bt_ctf_put(ret_event_class);
 
 	simple_event = bt_ctf_event_create(simple_event_class);
 	ok(simple_event,
@@ -605,7 +606,7 @@ void append_simple_event(struct bt_ctf_stream_class *stream_class,
 	ret_clock = bt_ctf_event_get_clock(simple_event);
 	ok(ret_clock == clock,
 		"bt_ctf_event_get_clock returns a correct clock");
-	bt_ctf_clock_put(clock);
+	bt_ctf_put(clock);
 
 	integer_field = bt_ctf_field_create(uint_12_type);
 	bt_ctf_field_unsigned_integer_set_value(integer_field, 42);
@@ -696,7 +697,7 @@ void append_simple_event(struct bt_ctf_stream_class *stream_class,
 		"packet_size");
 	ok(packet_context_field,
 		"Packet context contains the default packet_size field.");
-	bt_ctf_field_put(packet_context_field);
+	bt_ctf_put(packet_context_field);
 	packet_context_field = bt_ctf_field_structure_get_field(packet_context,
 		"custom_packet_context_field");
 	ok(bt_ctf_field_unsigned_integer_set_value(packet_context_field, 8) == 0,
@@ -712,27 +713,27 @@ void append_simple_event(struct bt_ctf_stream_class *stream_class,
 	ok(bt_ctf_stream_flush(stream) == 0,
 		"Flush trace stream with one event");
 
-	bt_ctf_event_class_put(simple_event_class);
-	bt_ctf_event_put(simple_event);
-	bt_ctf_field_type_put(uint_12_type);
-	bt_ctf_field_type_put(int_64_type);
-	bt_ctf_field_type_put(float_type);
-	bt_ctf_field_type_put(enum_type);
-	bt_ctf_field_type_put(enum_type_unsigned);
-	bt_ctf_field_type_put(returned_type);
-	bt_ctf_field_type_put(event_context_type);
-	bt_ctf_field_put(integer_field);
-	bt_ctf_field_put(float_field);
-	bt_ctf_field_put(enum_field);
-	bt_ctf_field_put(enum_field_unsigned);
-	bt_ctf_field_put(enum_container_field);
-	bt_ctf_field_put(enum_container_field_unsigned);
-	bt_ctf_field_put(packet_context);
-	bt_ctf_field_put(packet_context_field);
-	bt_ctf_field_put(stream_event_context);
-	bt_ctf_field_put(stream_event_context_field);
-	bt_ctf_field_put(event_context);
-	bt_ctf_field_put(event_context_field);
+	bt_ctf_put(simple_event_class);
+	bt_ctf_put(simple_event);
+	bt_ctf_put(uint_12_type);
+	bt_ctf_put(int_64_type);
+	bt_ctf_put(float_type);
+	bt_ctf_put(enum_type);
+	bt_ctf_put(enum_type_unsigned);
+	bt_ctf_put(returned_type);
+	bt_ctf_put(event_context_type);
+	bt_ctf_put(integer_field);
+	bt_ctf_put(float_field);
+	bt_ctf_put(enum_field);
+	bt_ctf_put(enum_field_unsigned);
+	bt_ctf_put(enum_container_field);
+	bt_ctf_put(enum_container_field_unsigned);
+	bt_ctf_put(packet_context);
+	bt_ctf_put(packet_context_field);
+	bt_ctf_put(stream_event_context);
+	bt_ctf_put(stream_event_context_field);
+	bt_ctf_put(event_context);
+	bt_ctf_put(event_context_field);
 }
 
 void append_complex_event(struct bt_ctf_stream_class *stream_class,
@@ -805,7 +806,7 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 		array_type);
 	ok(ret_field_type == int_16_type,
 		"bt_ctf_field_type_array_get_element_type returns the correct type");
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(ret_field_type);
 
 	ok(bt_ctf_field_type_array_get_length(NULL) < 0,
 		"bt_ctf_field_type_array_get_length handles NULL correctly");
@@ -857,7 +858,7 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 	ret_field_type = bt_ctf_field_type_variant_get_tag_type(variant_type);
 	ok(ret_field_type == enum_variant_type,
 		"bt_ctf_field_type_variant_get_tag_type returns a correct tag type");
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(ret_field_type);
 
 	ok(bt_ctf_field_type_variant_get_tag_name(NULL) == NULL,
 		"bt_ctf_field_type_variant_get_tag_name handles NULL correctly");
@@ -874,7 +875,7 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 		variant_type, "INT16_TYPE");
 	ok(ret_field_type == int_16_type,
 		"bt_ctf_field_type_variant_get_field_type_by_name returns a correct field type");
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(ret_field_type);
 
 	ok(bt_ctf_field_type_variant_get_field_count(NULL) < 0,
 		"bt_ctf_field_type_variant_get_field_count handles NULL correctly");
@@ -885,7 +886,7 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 		"bt_ctf_field_type_variant_get_field handles a NULL type correctly");
 	ok(bt_ctf_field_type_variant_get_field(variant_type, NULL, &ret_field_type, 0) == 0,
 		"bt_ctf_field_type_variant_get_field handles a NULL field name correctly");
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(ret_field_type);
 	ok(bt_ctf_field_type_variant_get_field(variant_type, &ret_string, NULL, 0) == 0,
 		"bt_ctf_field_type_variant_get_field handles a NULL field type correctly");
 	ok(bt_ctf_field_type_variant_get_field(variant_type, &ret_string, &ret_field_type, 200) < 0,
@@ -896,7 +897,7 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 		"bt_ctf_field_type_variant_get_field returns a correct field name");
 	ok(ret_field_type == int_16_type,
 		"bt_ctf_field_type_variant_get_field returns a correct field type");
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(ret_field_type);
 
 	bt_ctf_field_type_structure_add_field(complex_structure_type,
 		enum_variant_type, "variant_selector");
@@ -1062,7 +1063,7 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 	ret_stream_class = bt_ctf_event_class_get_stream_class(event_class);
 	ok(ret_stream_class == stream_class,
 		"bt_ctf_event_class_get_stream_class returns the correct stream class");
-	bt_ctf_stream_class_put(ret_stream_class);
+	bt_ctf_put(ret_stream_class);
 
 	ok(bt_ctf_event_class_get_field_count(NULL) < 0,
 		"bt_ctf_event_class_get_field_count handles NULL correctly");
@@ -1075,7 +1076,7 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 	ok(bt_ctf_event_class_get_field(event_class, NULL,
 		&ret_field_type, 0) == 0,
 		"bt_ctf_event_class_get_field handles a NULL field name correctly");
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(ret_field_type);
 	ok(bt_ctf_event_class_get_field(event_class, &ret_string,
 		NULL, 0) == 0,
 		"bt_ctf_event_class_get_field handles a NULL field type correctly");
@@ -1087,7 +1088,7 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 		"bt_ctf_event_class_get_field returns a field");
 	ok(ret_field_type == uint_35_type,
 		"bt_ctf_event_class_get_field returns a correct field type");
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(ret_field_type);
 	ok(!strcmp(ret_string, "uint_35"),
 		"bt_ctf_event_class_get_field returns a correct field name");
 	ok(bt_ctf_event_class_get_field_by_name(NULL, "") == NULL,
@@ -1100,7 +1101,7 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 		"complex_structure");
 	ok(ret_field_type == complex_structure_type,
 		"bt_ctf_event_class_get_field_by_name returns a correct field type");
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(ret_field_type);
 
 	event = bt_ctf_event_create(event_class);
 	ok(event, "Instanciate a complex event");
@@ -1110,7 +1111,7 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 	ret_event_class = bt_ctf_event_get_class(event);
 	ok(ret_event_class == event_class,
 		"bt_ctf_event_get_class returns the correct event class");
-	bt_ctf_event_class_put(ret_event_class);
+	bt_ctf_put(ret_event_class);
 
 	uint_35_field = bt_ctf_event_get_payload(event, "uint_35");
 	if (!uint_35_field) {
@@ -1131,7 +1132,7 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 	ok(bt_ctf_field_signed_integer_get_value(uint_35_field,
 		&ret_signed_int) < 0,
 		"bt_ctf_field_signed_integer_get_value fails on an unsigned field");
-	bt_ctf_field_put(uint_35_field);
+	bt_ctf_put(uint_35_field);
 
 	int_16_field = bt_ctf_event_get_payload(event, "int_16");
 	bt_ctf_field_signed_integer_set_value(int_16_field, -12345);
@@ -1147,7 +1148,7 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 	ok(bt_ctf_field_unsigned_integer_get_value(int_16_field,
 		&ret_unsigned_int) < 0,
 		"bt_ctf_field_unsigned_integer_get_value fails on a signed field");
-	bt_ctf_field_put(int_16_field);
+	bt_ctf_put(int_16_field);
 
 	complex_structure_field = bt_ctf_event_get_payload(event,
 		"complex_structure");
@@ -1159,10 +1160,10 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 	inner_structure_field = bt_ctf_field_structure_get_field_by_index(
 		complex_structure_field, 3);
 	ret_field_type = bt_ctf_field_get_type(inner_structure_field);
-	bt_ctf_field_put(inner_structure_field);
+	bt_ctf_put(inner_structure_field);
 	ok(ret_field_type == inner_structure_type,
 		"bt_ctf_field_structure_get_field_by_index returns a correct field");
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(ret_field_type);
 
 	inner_structure_field = bt_ctf_field_structure_get_field(
 		complex_structure_field, "inner_structure");
@@ -1185,7 +1186,7 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 	int_16_field = bt_ctf_field_variant_get_field(variant_field,
 		enum_variant_field);
 	bt_ctf_field_signed_integer_set_value(int_16_field, -200);
-	bt_ctf_field_put(int_16_field);
+	bt_ctf_put(int_16_field);
 	ok(!bt_ctf_field_string_get_value(a_string_field),
 		"bt_ctf_field_string_get_value returns NULL on an unset field");
 	bt_ctf_field_string_set_value(a_string_field,
@@ -1243,14 +1244,14 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 		int_16_field = bt_ctf_field_sequence_get_field(
 			a_sequence_field, i);
 		bt_ctf_field_signed_integer_set_value(int_16_field, 4 - i);
-		bt_ctf_field_put(int_16_field);
+		bt_ctf_put(int_16_field);
 	}
 
 	for (i = 0; i < ARRAY_TEST_LENGTH; i++) {
 		int_16_field = bt_ctf_field_array_get_field(
 			an_array_field, i);
 		bt_ctf_field_signed_integer_set_value(int_16_field, i);
-		bt_ctf_field_put(int_16_field);
+		bt_ctf_put(int_16_field);
 	}
 
 	bt_ctf_clock_set_time(clock, ++current_time);
@@ -1269,31 +1270,31 @@ void append_complex_event(struct bt_ctf_stream_class *stream_class,
 	ok(bt_ctf_stream_flush(stream) == 0,
 		"Flush a stream containing a complex event");
 
-	bt_ctf_field_put(uint_35_field);
-	bt_ctf_field_put(a_string_field);
-	bt_ctf_field_put(inner_structure_field);
-	bt_ctf_field_put(complex_structure_field);
-	bt_ctf_field_put(a_sequence_field);
-	bt_ctf_field_put(an_array_field);
-	bt_ctf_field_put(enum_variant_field);
-	bt_ctf_field_put(enum_container_field);
-	bt_ctf_field_put(variant_field);
-	bt_ctf_field_put(ret_field);
-	bt_ctf_field_put(packet_context_field);
-	bt_ctf_field_put(packet_context);
-	bt_ctf_field_type_put(uint_35_type);
-	bt_ctf_field_type_put(int_16_type);
-	bt_ctf_field_type_put(string_type);
-	bt_ctf_field_type_put(sequence_type);
-	bt_ctf_field_type_put(array_type);
-	bt_ctf_field_type_put(inner_structure_type);
-	bt_ctf_field_type_put(complex_structure_type);
-	bt_ctf_field_type_put(uint_3_type);
-	bt_ctf_field_type_put(enum_variant_type);
-	bt_ctf_field_type_put(variant_type);
-	bt_ctf_field_type_put(ret_field_type);
-	bt_ctf_event_class_put(event_class);
-	bt_ctf_event_put(event);
+	bt_ctf_put(uint_35_field);
+	bt_ctf_put(a_string_field);
+	bt_ctf_put(inner_structure_field);
+	bt_ctf_put(complex_structure_field);
+	bt_ctf_put(a_sequence_field);
+	bt_ctf_put(an_array_field);
+	bt_ctf_put(enum_variant_field);
+	bt_ctf_put(enum_container_field);
+	bt_ctf_put(variant_field);
+	bt_ctf_put(ret_field);
+	bt_ctf_put(packet_context_field);
+	bt_ctf_put(packet_context);
+	bt_ctf_put(uint_35_type);
+	bt_ctf_put(int_16_type);
+	bt_ctf_put(string_type);
+	bt_ctf_put(sequence_type);
+	bt_ctf_put(array_type);
+	bt_ctf_put(inner_structure_type);
+	bt_ctf_put(complex_structure_type);
+	bt_ctf_put(uint_3_type);
+	bt_ctf_put(enum_variant_type);
+	bt_ctf_put(variant_type);
+	bt_ctf_put(ret_field_type);
+	bt_ctf_put(event_class);
+	bt_ctf_put(event);
 }
 
 static void field_copy_tests_validate_same_type(struct bt_ctf_field *field,
@@ -1304,7 +1305,7 @@ static void field_copy_tests_validate_same_type(struct bt_ctf_field *field,
 	copy_type = bt_ctf_field_get_type(field);
 	ok(copy_type == expected_type,
 		"bt_ctf_field_copy does not copy the type (%s)", name);
-	bt_ctf_field_type_put(copy_type);
+	bt_ctf_put(copy_type);
 }
 
 static void field_copy_tests_validate_diff_ptrs(struct bt_ctf_field *field_a,
@@ -1503,7 +1504,7 @@ void field_copy_tests()
 	v_selected_cur = bt_ctf_field_variant_get_current_field(v);
 	ok(v_selected_cur == v_selected,
 		"bt_ctf_field_variant_get_current_field returns the current field");
-	bt_ctf_field_put(v_selected_cur);
+	bt_ctf_put(v_selected_cur);
 
 	/* set selected v field */
 	ret = bt_ctf_field_sequence_set_length(v_selected, len);
@@ -1710,7 +1711,7 @@ void field_copy_tests()
 	assert(!ret);
 	ok(uint64_t_val == 7,
 		"bt_ctf_field_copy creates a sequence field copy with the proper length");
-	bt_ctf_field_put(v_selected_copy_len);
+	bt_ctf_put(v_selected_copy_len);
 	v_selected_copy_len = NULL;
 
 	/* validate v_selected copy fields */
@@ -1768,59 +1769,59 @@ void field_copy_tests()
 		"bt_ctf_field_copy creates a valid array field element copy (a_4)");
 
 	/* put everything */
-	bt_ctf_field_type_put(len_type);
-	bt_ctf_field_type_put(fp_type);
-	bt_ctf_field_type_put(s_type);
-	bt_ctf_field_type_put(e_int_type);
-	bt_ctf_field_type_put(e_type);
-	bt_ctf_field_type_put(v_type);
-	bt_ctf_field_type_put(v_label1_type);
-	bt_ctf_field_type_put(v_label1_array_type);
-	bt_ctf_field_type_put(v_label2_type);
-	bt_ctf_field_type_put(v_label2_seq_type);
-	bt_ctf_field_type_put(strct_type);
-	bt_ctf_field_put(len);
-	bt_ctf_field_put(fp);
-	bt_ctf_field_put(s);
-	bt_ctf_field_put(e_int);
-	bt_ctf_field_put(e);
-	bt_ctf_field_put(v);
-	bt_ctf_field_put(v_selected);
-	bt_ctf_field_put(v_selected_0);
-	bt_ctf_field_put(v_selected_1);
-	bt_ctf_field_put(v_selected_2);
-	bt_ctf_field_put(v_selected_3);
-	bt_ctf_field_put(v_selected_4);
-	bt_ctf_field_put(v_selected_5);
-	bt_ctf_field_put(v_selected_6);
-	bt_ctf_field_put(a);
-	bt_ctf_field_put(a_0);
-	bt_ctf_field_put(a_1);
-	bt_ctf_field_put(a_2);
-	bt_ctf_field_put(a_3);
-	bt_ctf_field_put(a_4);
-	bt_ctf_field_put(strct);
-	bt_ctf_field_put(len_copy);
-	bt_ctf_field_put(fp_copy);
-	bt_ctf_field_put(s_copy);
-	bt_ctf_field_put(e_int_copy);
-	bt_ctf_field_put(e_copy);
-	bt_ctf_field_put(v_copy);
-	bt_ctf_field_put(v_selected_copy);
-	bt_ctf_field_put(v_selected_0_copy);
-	bt_ctf_field_put(v_selected_1_copy);
-	bt_ctf_field_put(v_selected_2_copy);
-	bt_ctf_field_put(v_selected_3_copy);
-	bt_ctf_field_put(v_selected_4_copy);
-	bt_ctf_field_put(v_selected_5_copy);
-	bt_ctf_field_put(v_selected_6_copy);
-	bt_ctf_field_put(a_copy);
-	bt_ctf_field_put(a_0_copy);
-	bt_ctf_field_put(a_1_copy);
-	bt_ctf_field_put(a_2_copy);
-	bt_ctf_field_put(a_3_copy);
-	bt_ctf_field_put(a_4_copy);
-	bt_ctf_field_put(strct_copy);
+	bt_ctf_put(len_type);
+	bt_ctf_put(fp_type);
+	bt_ctf_put(s_type);
+	bt_ctf_put(e_int_type);
+	bt_ctf_put(e_type);
+	bt_ctf_put(v_type);
+	bt_ctf_put(v_label1_type);
+	bt_ctf_put(v_label1_array_type);
+	bt_ctf_put(v_label2_type);
+	bt_ctf_put(v_label2_seq_type);
+	bt_ctf_put(strct_type);
+	bt_ctf_put(len);
+	bt_ctf_put(fp);
+	bt_ctf_put(s);
+	bt_ctf_put(e_int);
+	bt_ctf_put(e);
+	bt_ctf_put(v);
+	bt_ctf_put(v_selected);
+	bt_ctf_put(v_selected_0);
+	bt_ctf_put(v_selected_1);
+	bt_ctf_put(v_selected_2);
+	bt_ctf_put(v_selected_3);
+	bt_ctf_put(v_selected_4);
+	bt_ctf_put(v_selected_5);
+	bt_ctf_put(v_selected_6);
+	bt_ctf_put(a);
+	bt_ctf_put(a_0);
+	bt_ctf_put(a_1);
+	bt_ctf_put(a_2);
+	bt_ctf_put(a_3);
+	bt_ctf_put(a_4);
+	bt_ctf_put(strct);
+	bt_ctf_put(len_copy);
+	bt_ctf_put(fp_copy);
+	bt_ctf_put(s_copy);
+	bt_ctf_put(e_int_copy);
+	bt_ctf_put(e_copy);
+	bt_ctf_put(v_copy);
+	bt_ctf_put(v_selected_copy);
+	bt_ctf_put(v_selected_0_copy);
+	bt_ctf_put(v_selected_1_copy);
+	bt_ctf_put(v_selected_2_copy);
+	bt_ctf_put(v_selected_3_copy);
+	bt_ctf_put(v_selected_4_copy);
+	bt_ctf_put(v_selected_5_copy);
+	bt_ctf_put(v_selected_6_copy);
+	bt_ctf_put(a_copy);
+	bt_ctf_put(a_0_copy);
+	bt_ctf_put(a_1_copy);
+	bt_ctf_put(a_2_copy);
+	bt_ctf_put(a_3_copy);
+	bt_ctf_put(a_4_copy);
+	bt_ctf_put(strct_copy);
 }
 
 void type_field_tests()
@@ -1947,7 +1948,7 @@ void type_field_tests()
 		sequence_type);
 	ok(returned_type == int_16_type,
 		"bt_ctf_field_type_sequence_get_element_type returns the correct type");
-	bt_ctf_field_type_put(returned_type);
+	bt_ctf_put(returned_type);
 
 	string_type = bt_ctf_field_type_string_create();
 	ok(string_type, "Create a string type");
@@ -1991,7 +1992,7 @@ void type_field_tests()
 	ok(bt_ctf_field_type_structure_get_field(structure_seq_type,
 		NULL, &returned_type, 1) == 0,
 		"bt_ctf_field_type_structure_get_field handles a NULL name correctly");
-	bt_ctf_field_type_put(returned_type);
+	bt_ctf_put(returned_type);
 	ok(bt_ctf_field_type_structure_get_field(structure_seq_type,
 		&ret_string, NULL, 1) == 0,
 		"bt_ctf_field_type_structure_get_field handles a NULL return type correctly");
@@ -2005,7 +2006,7 @@ void type_field_tests()
 		"bt_ctf_field_type_structure_get_field returns a correct field name");
 	ok(returned_type == sequence_type,
 		"bt_ctf_field_type_structure_get_field returns a correct field type");
-	bt_ctf_field_type_put(returned_type);
+	bt_ctf_put(returned_type);
 
 	ok(bt_ctf_field_type_structure_get_field_type_by_name(NULL, "a_sequence") == NULL,
 		"bt_ctf_field_type_structure_get_field_type_by_name handles a NULL structure correctly");
@@ -2015,7 +2016,7 @@ void type_field_tests()
 		structure_seq_type, "a_sequence");
 	ok(returned_type == sequence_type,
 		"bt_ctf_field_type_structure_get_field_type_by_name returns the correct field type");
-	bt_ctf_field_type_put(returned_type);
+	bt_ctf_put(returned_type);
 
 	composite_structure_type = bt_ctf_field_type_structure_create();
 	ok(bt_ctf_field_type_structure_add_field(composite_structure_type,
@@ -2035,7 +2036,7 @@ void type_field_tests()
 		structure_seq_type, "a_sequence");
 	ok(returned_type == sequence_type,
 		"bt_ctf_field_type_structure_get_field_type_by_name returns a correct type");
-	bt_ctf_field_type_put(returned_type);
+	bt_ctf_put(returned_type);
 
 	int_16 = bt_ctf_field_create(int_16_type);
 	ok(int_16, "Instanciate a signed 16-bit integer");
@@ -2100,21 +2101,21 @@ void type_field_tests()
 	ok(!enumeration,
 		"Check enumeration types are validated before instantiation");
 
-	bt_ctf_field_put(string);
-	bt_ctf_field_put(uint_12);
-	bt_ctf_field_put(int_16);
-	bt_ctf_field_put(enumeration);
-	bt_ctf_field_type_put(composite_structure_type);
-	bt_ctf_field_type_put(structure_seq_type);
-	bt_ctf_field_type_put(string_type);
-	bt_ctf_field_type_put(sequence_type);
-	bt_ctf_field_type_put(uint_8_type);
-	bt_ctf_field_type_put(int_16_type);
-	bt_ctf_field_type_put(uint_12_type);
-	bt_ctf_field_type_put(enumeration_type);
-	bt_ctf_field_type_put(enumeration_sequence_type);
-	bt_ctf_field_type_put(enumeration_array_type);
-	bt_ctf_field_type_put(returned_type);
+	bt_ctf_put(string);
+	bt_ctf_put(uint_12);
+	bt_ctf_put(int_16);
+	bt_ctf_put(enumeration);
+	bt_ctf_put(composite_structure_type);
+	bt_ctf_put(structure_seq_type);
+	bt_ctf_put(string_type);
+	bt_ctf_put(sequence_type);
+	bt_ctf_put(uint_8_type);
+	bt_ctf_put(int_16_type);
+	bt_ctf_put(uint_12_type);
+	bt_ctf_put(enumeration_type);
+	bt_ctf_put(enumeration_sequence_type);
+	bt_ctf_put(enumeration_array_type);
+	bt_ctf_put(returned_type);
 }
 
 void packet_resize_test(struct bt_ctf_stream_class *stream_class,
@@ -2156,14 +2157,14 @@ void packet_resize_test(struct bt_ctf_stream_class *stream_class,
 	ret_field_type = bt_ctf_field_get_type(ret_field);
 	ok(ret_field_type == integer_type,
 		"bt_ctf_event_get_payload_by_index returns a correct field");
-	bt_ctf_field_type_put(ret_field_type);
-	bt_ctf_field_put(ret_field);
+	bt_ctf_put(ret_field_type);
+	bt_ctf_put(ret_field);
 
 	ok(bt_ctf_event_get_payload_by_index(NULL, 0) == NULL,
 		"bt_ctf_event_get_payload_by_index handles NULL correctly");
 	ok(bt_ctf_event_get_payload_by_index(event, 4) == NULL,
 		"bt_ctf_event_get_payload_by_index handles an invalid index correctly");
-	bt_ctf_event_put(event);
+	bt_ctf_put(event);
 
 	ok(bt_ctf_stream_get_event_context(NULL) == NULL,
 		"bt_ctf_stream_get_event_context handles NULL correctly");
@@ -2179,7 +2180,7 @@ void packet_resize_test(struct bt_ctf_stream_class *stream_class,
 	ret_field = bt_ctf_field_create(integer_type);
 	ok(bt_ctf_stream_set_event_context(stream, ret_field) < 0,
 		"bt_ctf_stream_set_event_context rejects an event context of incorrect type");
-	bt_ctf_field_put(ret_field);
+	bt_ctf_put(ret_field);
 
 	for (i = 0; i < PACKET_RESIZE_TEST_LENGTH; i++) {
 		event = bt_ctf_event_create(event_class);
@@ -2192,21 +2193,21 @@ void packet_resize_test(struct bt_ctf_stream_class *stream_class,
 		ret |= bt_ctf_field_unsigned_integer_set_value(integer, i);
 		ret |= bt_ctf_event_set_payload(event, "field_1",
 			integer);
-		bt_ctf_field_put(integer);
+		bt_ctf_put(integer);
 		ret |= bt_ctf_field_string_set_value(string, "This is a test");
 		ret |= bt_ctf_event_set_payload(event, "a_string",
 			string);
-		bt_ctf_field_put(string);
+		bt_ctf_put(string);
 
 		/* Populate stream event context */
 		integer = bt_ctf_field_structure_get_field(event_context,
 			"common_event_context");
 		ret |= bt_ctf_field_unsigned_integer_set_value(integer,
 			i % 42);
-		bt_ctf_field_put(integer);
+		bt_ctf_put(integer);
 
 		ret |= bt_ctf_stream_append_event(stream, event);
-		bt_ctf_event_put(event);
+		bt_ctf_put(event);
 
 		if (ret) {
 			break;
@@ -2243,12 +2244,12 @@ end:
 	ret = bt_ctf_stream_get_discarded_events_count(stream, &ret_uint64);
 	ok(ret == 0 && ret_uint64 == 1000,
 		"bt_ctf_stream_get_discarded_events_count returns a correct number of discarded events after a flush");
-	bt_ctf_field_type_put(integer_type);
-	bt_ctf_field_type_put(string_type);
-	bt_ctf_field_put(packet_context);
-	bt_ctf_field_put(packet_context_field);
-	bt_ctf_field_put(event_context);
-	bt_ctf_event_class_put(event_class);
+	bt_ctf_put(integer_type);
+	bt_ctf_put(string_type);
+	bt_ctf_put(packet_context);
+	bt_ctf_put(packet_context_field);
+	bt_ctf_put(event_context);
+	bt_ctf_put(event_class);
 }
 
 void test_empty_stream(struct bt_ctf_writer *writer)
@@ -2290,10 +2291,10 @@ void test_empty_stream(struct bt_ctf_writer *writer)
 end:
 	ok(ret == 0,
 		"Created a stream class with default attributes and an empty stream");
-	bt_ctf_trace_put(trace);
-	bt_ctf_trace_put(ret_trace);
-	bt_ctf_stream_put(stream);
-	bt_ctf_stream_class_put(stream_class);
+	bt_ctf_put(trace);
+	bt_ctf_put(ret_trace);
+	bt_ctf_put(stream);
+	bt_ctf_put(stream_class);
 }
 
 void test_custom_event_header_stream(struct bt_ctf_writer *writer)
@@ -2417,7 +2418,7 @@ void test_custom_event_header_stream(struct bt_ctf_writer *writer)
 		fail("Failed to set custom_trace_packet_header_field value");
 		goto end;
 	}
-	bt_ctf_field_put(integer);
+	bt_ctf_put(integer);
 
 	event = bt_ctf_event_create(event_class);
 	if (!event) {
@@ -2456,7 +2457,7 @@ void test_custom_event_header_stream(struct bt_ctf_writer *writer)
 		fail("Failed to set sequence length");
 		goto end;
 	}
-	bt_ctf_field_put(integer);
+	bt_ctf_put(integer);
 
 	for (i = 0; i < 2; i++) {
 		integer = bt_ctf_field_sequence_get_field(sequence, i);
@@ -2471,7 +2472,7 @@ void test_custom_event_header_stream(struct bt_ctf_writer *writer)
 			goto end;
 		}
 
-		bt_ctf_field_put(integer);
+		bt_ctf_put(integer);
 		integer = NULL;
 	}
 
@@ -2486,19 +2487,19 @@ void test_custom_event_header_stream(struct bt_ctf_writer *writer)
 		fail("Failed to flush custom_event_header stream");
 	}
 end:
-	bt_ctf_clock_put(clock);
-	bt_ctf_trace_put(trace);
-	bt_ctf_stream_put(stream);
-	bt_ctf_stream_class_put(stream_class);
-	bt_ctf_event_class_put(event_class);
-	bt_ctf_event_put(event);
-	bt_ctf_field_put(integer);
-	bt_ctf_field_put(sequence);
-	bt_ctf_field_put(event_header);
-	bt_ctf_field_put(packet_header);
-	bt_ctf_field_type_put(sequence_type);
-	bt_ctf_field_type_put(integer_type);
-	bt_ctf_field_type_put(event_header_type);
+	bt_ctf_put(clock);
+	bt_ctf_put(trace);
+	bt_ctf_put(stream);
+	bt_ctf_put(stream_class);
+	bt_ctf_put(event_class);
+	bt_ctf_put(event);
+	bt_ctf_put(integer);
+	bt_ctf_put(sequence);
+	bt_ctf_put(event_header);
+	bt_ctf_put(packet_header);
+	bt_ctf_put(sequence_type);
+	bt_ctf_put(integer_type);
+	bt_ctf_put(event_header_type);
 }
 
 void test_instanciate_event_before_stream(struct bt_ctf_writer *writer)
@@ -2606,15 +2607,15 @@ void test_instanciate_event_before_stream(struct bt_ctf_writer *writer)
 end:
 	ok(ret == 0,
 		"Create an event before instanciating its associated stream");
-	bt_ctf_trace_put(trace);
-	bt_ctf_stream_put(stream);
-	bt_ctf_stream_put(ret_stream);
-	bt_ctf_stream_class_put(stream_class);
-	bt_ctf_event_class_put(event_class);
-	bt_ctf_event_put(event);
-	bt_ctf_field_type_put(integer_type);
-	bt_ctf_field_put(integer);
-	bt_ctf_clock_put(clock);
+	bt_ctf_put(trace);
+	bt_ctf_put(stream);
+	bt_ctf_put(ret_stream);
+	bt_ctf_put(stream_class);
+	bt_ctf_put(event_class);
+	bt_ctf_put(event);
+	bt_ctf_put(integer_type);
+	bt_ctf_put(integer);
+	bt_ctf_put(clock);
 }
 
 void append_existing_event_class(struct bt_ctf_stream_class *stream_class)
@@ -2624,14 +2625,14 @@ void append_existing_event_class(struct bt_ctf_stream_class *stream_class)
 	assert(event_class = bt_ctf_event_class_create("Simple Event"));
 	ok(bt_ctf_stream_class_add_event_class(stream_class, event_class),
 		"two event classes with the same name cannot cohabit within the same stream class");
-	bt_ctf_event_class_put(event_class);
+	bt_ctf_put(event_class);
 
 	event_class = bt_ctf_event_class_create("different name, ok");
 	assert(event_class);
 	assert(!bt_ctf_event_class_set_id(event_class, 11));
 	ok(bt_ctf_stream_class_add_event_class(stream_class, event_class),
 		"two event classes with the same ID cannot cohabit within the same stream class");
-	bt_ctf_event_class_put(event_class);
+	bt_ctf_put(event_class);
 }
 
 int main(int argc, char **argv)
@@ -2937,7 +2938,7 @@ int main(int argc, char **argv)
 	ret_clock = bt_ctf_trace_get_clock(trace, 0);
 	ok(ret_clock == clock,
 		"bt_ctf_trace_get_clock returns the right clock instance");
-	bt_ctf_clock_put(ret_clock);
+	bt_ctf_put(ret_clock);
 	ok(!bt_ctf_trace_get_clock_by_name(trace, NULL),
 		"bt_ctf_trace_get_clock_by_name correctly handles NULL (trace)");
 	ok(!bt_ctf_trace_get_clock_by_name(NULL, clock_name),
@@ -2947,7 +2948,7 @@ int main(int argc, char **argv)
 	ret_clock = bt_ctf_trace_get_clock_by_name(trace, clock_name);
 	ok(ret_clock == clock,
 		"bt_ctf_trace_get_clock_by_name returns the right clock instance");
-	bt_ctf_clock_put(ret_clock);
+	bt_ctf_put(ret_clock);
 	ok(!bt_ctf_trace_get_clock_by_name(trace, "random"),
 		"bt_ctf_trace_get_clock_by_name fails when the requested clock doesn't exist");
 
@@ -3025,7 +3026,7 @@ int main(int argc, char **argv)
 	ret_clock = bt_ctf_stream_class_get_clock(stream_class);
 	ok(ret_clock == clock,
 		"bt_ctf_stream_class_get_clock returns a correct clock");
-	bt_ctf_clock_put(ret_clock);
+	bt_ctf_put(ret_clock);
 
 	/* Test the event fields and event types APIs */
 	type_field_tests();
@@ -3061,7 +3062,7 @@ int main(int argc, char **argv)
 	ok(bt_ctf_field_type_get_type_id(
 		event_header_field_type) == CTF_TYPE_INTEGER,
 		"Default event header \"id\" field is an integer");
-	bt_ctf_field_type_put(event_header_field_type);
+	bt_ctf_put(event_header_field_type);
 	event_header_field_type =
 		bt_ctf_field_type_structure_get_field_type_by_name(
 		ret_field_type, "timestamp");
@@ -3070,8 +3071,8 @@ int main(int argc, char **argv)
 	ok(bt_ctf_field_type_get_type_id(
 		event_header_field_type) == CTF_TYPE_INTEGER,
 		"Default event header \"timestamp\" field is an integer");
-	bt_ctf_field_type_put(event_header_field_type);
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(event_header_field_type);
+	bt_ctf_put(ret_field_type);
 
 	/* Add a custom trace packet header field */
 	ok(bt_ctf_trace_get_packet_header_type(NULL) == NULL,
@@ -3084,15 +3085,15 @@ int main(int argc, char **argv)
 	ret_field_type = bt_ctf_field_type_structure_get_field_type_by_name(
 		packet_header_type, "magic");
 	ok(ret_field_type, "Default packet header type contains a \"magic\" field");
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(ret_field_type);
 	ret_field_type = bt_ctf_field_type_structure_get_field_type_by_name(
 		packet_header_type, "uuid");
 	ok(ret_field_type, "Default packet header type contains a \"uuid\" field");
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(ret_field_type);
 	ret_field_type = bt_ctf_field_type_structure_get_field_type_by_name(
 		packet_header_type, "stream_id");
 	ok(ret_field_type, "Default packet header type contains a \"stream_id\" field");
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(ret_field_type);
 
 	packet_header_field_type = bt_ctf_field_type_integer_create(22);
 	ok(!bt_ctf_field_type_structure_add_field(packet_header_type,
@@ -3159,7 +3160,7 @@ int main(int argc, char **argv)
 		stream_class);
 	ok(ret_field_type == stream_event_context_type,
 		"bt_ctf_stream_class_get_event_context_type returns the correct field type.");
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(ret_field_type);
 
 	/* Instantiate a stream and append events */
 	stream1 = bt_ctf_writer_create_stream(writer, stream_class);
@@ -3213,7 +3214,7 @@ int main(int argc, char **argv)
 	ret_field_type = bt_ctf_field_get_type(packet_header);
 	ok(ret_field_type == packet_header_type,
 		"Stream returns a packet header of the appropriate type");
-	bt_ctf_field_type_put(ret_field_type);
+	bt_ctf_put(ret_field_type);
 	packet_header_field = bt_ctf_field_structure_get_field(packet_header,
 		"custom_trace_packet_header_field");
 	ok(packet_header_field,
@@ -3256,25 +3257,25 @@ int main(int argc, char **argv)
 	validate_metadata(argv[1], metadata_path);
 	validate_trace(argv[2], trace_path);
 
-	bt_ctf_clock_put(clock);
-	bt_ctf_stream_class_put(ret_stream_class);
-	bt_ctf_writer_put(writer);
-	bt_ctf_stream_put(stream1);
-	bt_ctf_field_type_put(packet_context_type);
-	bt_ctf_field_type_put(packet_context_field_type);
-	bt_ctf_field_type_put(integer_type);
-	bt_ctf_field_type_put(stream_event_context_type);
-	bt_ctf_field_type_put(ret_field_type);
-	bt_ctf_field_type_put(packet_header_type);
-	bt_ctf_field_type_put(packet_header_field_type);
-	bt_ctf_field_put(packet_header);
-	bt_ctf_field_put(packet_header_field);
-	bt_ctf_trace_put(trace);
+	bt_ctf_put(clock);
+	bt_ctf_put(ret_stream_class);
+	bt_ctf_put(writer);
+	bt_ctf_put(stream1);
+	bt_ctf_put(packet_context_type);
+	bt_ctf_put(packet_context_field_type);
+	bt_ctf_put(integer_type);
+	bt_ctf_put(stream_event_context_type);
+	bt_ctf_put(ret_field_type);
+	bt_ctf_put(packet_header_type);
+	bt_ctf_put(packet_header_field_type);
+	bt_ctf_put(packet_header);
+	bt_ctf_put(packet_header_field);
+	bt_ctf_put(trace);
 	free(metadata_string);
 
 	ok(bt_ctf_stream_class_get_trace(stream_class) == NULL,
 		"bt_ctf_stream_class_get_trace returns NULL after its trace has been reclaimed");
-	bt_ctf_stream_class_put(stream_class);
+	bt_ctf_put(stream_class);
 
 	/* Remove all trace files and delete temporary trace directory */
 	DIR *trace_dir = opendir(trace_path);


### PR DESCRIPTION
See commit msg of 79b2450.

Valgrind reports 0 leaks when running `test_ctf_writer` after having merged this PR :ok_hand:.