### PR TITLE
IR: add type ID helpers

### DIFF
--- a/formats/ctf/ir/event-fields.c
+++ b/formats/ctf/ir/event-fields.c
@@ -282,6 +282,11 @@ end:
 	return ret;
 }
 
+enum ctf_type_id bt_ctf_field_get_type_id(struct bt_ctf_field *field)
+{
+	return bt_ctf_field_type_get_type_id(field->type);
+}
+
 struct bt_ctf_field *bt_ctf_field_sequence_get_length(
 		struct bt_ctf_field *field)
 {

--- a/formats/ctf/ir/event-fields.c
+++ b/formats/ctf/ir/event-fields.c
@@ -287,6 +287,46 @@ enum ctf_type_id bt_ctf_field_get_type_id(struct bt_ctf_field *field)
 	return bt_ctf_field_type_get_type_id(field->type);
 }
 
+int bt_ctf_field_is_integer(struct bt_ctf_field *field)
+{
+	return bt_ctf_field_get_type_id(field) == CTF_TYPE_INTEGER;
+}
+
+int bt_ctf_field_is_floating_point(struct bt_ctf_field *field)
+{
+	return bt_ctf_field_get_type_id(field) == CTF_TYPE_FLOAT;
+}
+
+int bt_ctf_field_is_enumeration(struct bt_ctf_field *field)
+{
+	return bt_ctf_field_get_type_id(field) == CTF_TYPE_ENUM;
+}
+
+int bt_ctf_field_is_string(struct bt_ctf_field *field)
+{
+	return bt_ctf_field_get_type_id(field) == CTF_TYPE_STRING;
+}
+
+int bt_ctf_field_is_structure(struct bt_ctf_field *field)
+{
+	return bt_ctf_field_get_type_id(field) == CTF_TYPE_STRUCT;
+}
+
+int bt_ctf_field_is_array(struct bt_ctf_field *field)
+{
+	return bt_ctf_field_get_type_id(field) == CTF_TYPE_ARRAY;
+}
+
+int bt_ctf_field_is_sequence(struct bt_ctf_field *field)
+{
+	return bt_ctf_field_get_type_id(field) == CTF_TYPE_SEQUENCE;
+}
+
+int bt_ctf_field_is_variant(struct bt_ctf_field *field)
+{
+	return bt_ctf_field_get_type_id(field) == CTF_TYPE_VARIANT;
+}
+
 struct bt_ctf_field *bt_ctf_field_sequence_get_length(
 		struct bt_ctf_field *field)
 {

--- a/formats/ctf/ir/event-types.c
+++ b/formats/ctf/ir/event-types.c
@@ -1922,6 +1922,46 @@ enum ctf_type_id bt_ctf_field_type_get_type_id(
 	return type->declaration->id;
 }
 
+int bt_ctf_field_type_is_integer(struct bt_ctf_field_type *type)
+{
+	return bt_ctf_field_type_get_type_id(type) == CTF_TYPE_INTEGER;
+}
+
+int bt_ctf_field_type_is_floating_point(struct bt_ctf_field_type *type)
+{
+	return bt_ctf_field_type_get_type_id(type) == CTF_TYPE_FLOAT;
+}
+
+int bt_ctf_field_type_is_enumeration(struct bt_ctf_field_type *type)
+{
+	return bt_ctf_field_type_get_type_id(type) == CTF_TYPE_ENUM;
+}
+
+int bt_ctf_field_type_is_string(struct bt_ctf_field_type *type)
+{
+	return bt_ctf_field_type_get_type_id(type) == CTF_TYPE_STRING;
+}
+
+int bt_ctf_field_type_is_structure(struct bt_ctf_field_type *type)
+{
+	return bt_ctf_field_type_get_type_id(type) == CTF_TYPE_STRUCT;
+}
+
+int bt_ctf_field_type_is_array(struct bt_ctf_field_type *type)
+{
+	return bt_ctf_field_type_get_type_id(type) == CTF_TYPE_ARRAY;
+}
+
+int bt_ctf_field_type_is_sequence(struct bt_ctf_field_type *type)
+{
+	return bt_ctf_field_type_get_type_id(type) == CTF_TYPE_SEQUENCE;
+}
+
+int bt_ctf_field_type_is_variant(struct bt_ctf_field_type *type)
+{
+	return bt_ctf_field_type_get_type_id(type) == CTF_TYPE_VARIANT;
+}
+
 void bt_ctf_field_type_get(struct bt_ctf_field_type *type)
 {
 	bt_ctf_get(type);

--- a/include/babeltrace/ctf-ir/event-fields.h
+++ b/include/babeltrace/ctf-ir/event-fields.h
@@ -367,6 +367,86 @@ extern struct bt_ctf_field_type *bt_ctf_field_get_type(
 extern enum ctf_type_id bt_ctf_field_get_type_id(struct bt_ctf_field *field);
 
 /*
+ * bt_ctf_field_is_integer: returns whether or not a given field
+ *	is an integer type.
+ *
+ * @param field Field instance.
+ *
+ * Returns 1 if the field instance is an integer type, 0 otherwise.
+ */
+extern int bt_ctf_field_is_integer(struct bt_ctf_field *field);
+
+/*
+ * bt_ctf_field_is_floating_point: returns whether or not a given field
+ *	is a floating point number type.
+ *
+ * @param field Field instance.
+ *
+ * Returns 1 if the field instance is a floating point number type, 0 otherwise.
+ */
+extern int bt_ctf_field_is_floating_point(struct bt_ctf_field *field);
+
+/*
+ * bt_ctf_field_is_enumeration: returns whether or not a given field
+ *	is an enumeration type.
+ *
+ * @param field Field instance.
+ *
+ * Returns 1 if the field instance is an enumeration type, 0 otherwise.
+ */
+extern int bt_ctf_field_is_enumeration(struct bt_ctf_field *field);
+
+/*
+ * bt_ctf_field_is_string: returns whether or not a given field
+ *	is a string type.
+ *
+ * @param field Field instance.
+ *
+ * Returns 1 if the field instance is a string type, 0 otherwise.
+ */
+extern int bt_ctf_field_is_string(struct bt_ctf_field *field);
+
+/*
+ * bt_ctf_field_is_structure: returns whether or not a given field
+ *	is a structure type.
+ *
+ * @param field Field instance.
+ *
+ * Returns 1 if the field instance is a structure type, 0 otherwise.
+ */
+extern int bt_ctf_field_is_structure(struct bt_ctf_field *field);
+
+/*
+ * bt_ctf_field_is_array: returns whether or not a given field
+ *	is an array type.
+ *
+ * @param field Field instance.
+ *
+ * Returns 1 if the field instance is an array type, 0 otherwise.
+ */
+extern int bt_ctf_field_is_array(struct bt_ctf_field *field);
+
+/*
+ * bt_ctf_field_is_sequence: returns whether or not a given field
+ *	is a sequence type.
+ *
+ * @param field Field instance.
+ *
+ * Returns 1 if the field instance is a sequence type, 0 otherwise.
+ */
+extern int bt_ctf_field_is_sequence(struct bt_ctf_field *field);
+
+/*
+ * bt_ctf_field_is_variant: returns whether or not a given field
+ *	is a variant type.
+ *
+ * @param field Field instance.
+ *
+ * Returns 1 if the field instance is a variant type, 0 otherwise.
+ */
+extern int bt_ctf_field_is_variant(struct bt_ctf_field *field);
+
+/*
  * bt_ctf_field_copy: get a field's deep copy.
  *
  * Get a field's deep copy. The created field copy shares the source's

--- a/include/babeltrace/ctf-ir/event-fields.h
+++ b/include/babeltrace/ctf-ir/event-fields.h
@@ -353,6 +353,20 @@ extern struct bt_ctf_field_type *bt_ctf_field_get_type(
 		struct bt_ctf_field *field);
 
 /*
+ * bt_ctf_field_get_type_id: get a field's ctf_type_id.
+ *
+ * This is a helper function which avoids a call to
+ * bt_ctf_field_get_type(), followed by a call to
+ * bt_ctf_field_type_get_type_id(), followed by a call to
+ * bt_ctf_put().
+ *
+ * @param field Field instance.
+ *
+ * Returns the field's ctf_type_id, CTF_TYPE_UNKNOWN on error.
+ */
+extern enum ctf_type_id bt_ctf_field_get_type_id(struct bt_ctf_field *field);
+
+/*
  * bt_ctf_field_copy: get a field's deep copy.
  *
  * Get a field's deep copy. The created field copy shares the source's

--- a/include/babeltrace/ctf-ir/event-types.h
+++ b/include/babeltrace/ctf-ir/event-types.h
@@ -752,6 +752,86 @@ extern enum ctf_type_id bt_ctf_field_type_get_type_id(
 		struct bt_ctf_field_type *type);
 
 /*
+ * bt_ctf_field_type_is_integer: returns whether or not a given field
+ *	type is an integer type.
+ *
+ * @param type Field type.
+ *
+ * Returns 1 if the field type is an integer type, 0 otherwise.
+ */
+extern int bt_ctf_field_type_is_integer(struct bt_ctf_field_type *type);
+
+/*
+ * bt_ctf_field_type_is_floating_point: returns whether or not a given field
+ *	type is a floating point number type.
+ *
+ * @param type Field type.
+ *
+ * Returns 1 if the field type is a floating point number type, 0 otherwise.
+ */
+extern int bt_ctf_field_type_is_floating_point(struct bt_ctf_field_type *type);
+
+/*
+ * bt_ctf_field_type_is_enumeration: returns whether or not a given field
+ *	type is an enumeration type.
+ *
+ * @param type Field type.
+ *
+ * Returns 1 if the field type is an enumeration type, 0 otherwise.
+ */
+extern int bt_ctf_field_type_is_enumeration(struct bt_ctf_field_type *type);
+
+/*
+ * bt_ctf_field_type_is_string: returns whether or not a given field
+ *	type is a string type.
+ *
+ * @param type Field type.
+ *
+ * Returns 1 if the field type is a string type, 0 otherwise.
+ */
+extern int bt_ctf_field_type_is_string(struct bt_ctf_field_type *type);
+
+/*
+ * bt_ctf_field_type_is_structure: returns whether or not a given field
+ *	type is a structure type.
+ *
+ * @param type Field type.
+ *
+ * Returns 1 if the field type is a structure type, 0 otherwise.
+ */
+extern int bt_ctf_field_type_is_structure(struct bt_ctf_field_type *type);
+
+/*
+ * bt_ctf_field_type_is_array: returns whether or not a given field
+ *	type is an array type.
+ *
+ * @param type Field type.
+ *
+ * Returns 1 if the field type is an array type, 0 otherwise.
+ */
+extern int bt_ctf_field_type_is_array(struct bt_ctf_field_type *type);
+
+/*
+ * bt_ctf_field_type_is_sequence: returns whether or not a given field
+ *	type is a sequence type.
+ *
+ * @param type Field type.
+ *
+ * Returns 1 if the field type is a sequence type, 0 otherwise.
+ */
+extern int bt_ctf_field_type_is_sequence(struct bt_ctf_field_type *type);
+
+/*
+ * bt_ctf_field_type_is_variant: returns whether or not a given field
+ *	type is a variant type.
+ *
+ * @param type Field type.
+ *
+ * Returns 1 if the field type is a variant type, 0 otherwise.
+ */
+extern int bt_ctf_field_type_is_variant(struct bt_ctf_field_type *type);
+
+/*
  * bt_ctf_field_type_get and bt_ctf_field_type_put: increment and decrement
  * the field type's reference count.
  *


### PR DESCRIPTION
Those are things we do all the time so why not providing them in the API?