### PR TITLE
CTF IR: make sure dynamic scopes always exist

### DIFF
--- a/formats/ctf/ir/event-fields.c
+++ b/formats/ctf/ir/event-fields.c
@@ -1257,7 +1257,7 @@ struct bt_ctf_field *bt_ctf_field_structure_create(
 		struct bt_ctf_field_structure, 1);
 	struct bt_ctf_field *field = NULL;
 
-	if (!structure || !structure_type->fields->len) {
+	if (!structure) {
 		goto end;
 	}
 

--- a/formats/ctf/ir/event.c
+++ b/formats/ctf/ir/event.c
@@ -63,6 +63,14 @@ struct bt_ctf_event_class *bt_ctf_event_class_create(const char *name)
 	}
 
 	bt_object_init(event_class, bt_ctf_event_class_destroy);
+
+	/* Empty structure as default event context type */
+	event_class->context = bt_ctf_field_type_structure_create();
+	if (!event_class->context) {
+		goto error;
+	}
+
+	/* Empty structure as default event payload type */
 	event_class->fields = bt_ctf_field_type_structure_create();
 	if (!event_class->fields) {
 		goto error;

--- a/formats/ctf/ir/stream-class.c
+++ b/formats/ctf/ir/stream-class.c
@@ -79,6 +79,12 @@ struct bt_ctf_stream_class *bt_ctf_stream_class_create(const char *name)
 		goto error;
 	}
 
+	/* Empty structure as default stream event context type */
+	stream_class->event_context_type = bt_ctf_field_type_structure_create();
+	if (!stream_class->event_context_type) {
+		goto error;
+	}
+
 	bt_object_init(stream_class, bt_ctf_stream_class_destroy);
 	return stream_class;
 

--- a/formats/ctf/ir/visitor.c
+++ b/formats/ctf/ir/visitor.c
@@ -273,10 +273,11 @@ int field_type_recursive_visit(struct bt_ctf_field_type *type,
 			ctf_type_stack_peek(context->stack);
 		int field_count = get_type_field_count(entry->type);
 
-		if (field_count <= 0) {
+		if (field_count <= 0 &&
+				!bt_ctf_field_type_is_structure(entry->type)) {
 			/*
 			 * Propagate error if one was given, else return
-			 * -1 since empty structures or variants are invalid
+			 * -1 since empty variants are invalid
 			 * at this point.
 			 */
 			ret = field_count < 0 ? field_count : -1;

--- a/tests/lib/test_ctf_writer.c
+++ b/tests/lib/test_ctf_writer.c
@@ -377,6 +377,7 @@ void append_simple_event(struct bt_ctf_stream_class *stream_class,
 		bt_ctf_field_type_enumeration_create(uint_12_type);
 	struct bt_ctf_field_type *event_context_type =
 		bt_ctf_field_type_structure_create();
+	struct bt_ctf_field_type *event_context_type_test;
 	struct bt_ctf_field_type *returned_type;
 	struct bt_ctf_event *simple_event;
 	struct bt_ctf_field *integer_field;
@@ -548,9 +549,10 @@ void append_simple_event(struct bt_ctf_stream_class *stream_class,
 		"Add event specific context field");
 	ok(bt_ctf_event_class_get_context_type(NULL) == NULL,
 		"bt_ctf_event_class_get_context_type handles NULL correctly");
-	ok(bt_ctf_event_class_get_context_type(simple_event_class) == NULL,
-		"bt_ctf_event_class_get_context_type returns NULL when no event context type is set");
-
+	event_context_type_test = bt_ctf_event_class_get_context_type(simple_event_class);
+	ok(event_context_type_test,
+		"event context type is always set");
+	BT_PUT(event_context_type_test);
 	ok(bt_ctf_event_class_set_context_type(simple_event_class, NULL) < 0,
 		"bt_ctf_event_class_set_context_type handles a NULL context type correctly");
 	ok(bt_ctf_event_class_set_context_type(NULL, event_context_type) < 0,
@@ -2673,7 +2675,8 @@ int main(int argc, char **argv)
 		*integer_type,
 		*stream_event_context_type,
 		*ret_field_type,
-		*event_header_field_type;
+		*event_header_field_type,
+		*stream_event_context_field_type;
 	struct bt_ctf_field *packet_header, *packet_header_field;
 	struct bt_ctf_trace *trace;
 	int ret;
@@ -3144,9 +3147,11 @@ int main(int argc, char **argv)
 	/* Define a stream event context containing a my_integer field. */
 	ok(bt_ctf_stream_class_get_event_context_type(NULL) == NULL,
 		"bt_ctf_stream_class_get_event_context_type handles NULL correctly");
-	ok(bt_ctf_stream_class_get_event_context_type(
-		stream_class) == NULL,
-		"bt_ctf_stream_class_get_event_context_type returns NULL when no stream event context type was set.");
+	stream_event_context_field_type =
+		bt_ctf_stream_class_get_event_context_type(stream_class);
+	ok(stream_event_context_field_type,
+		"stream event context type is always set");
+	BT_PUT(stream_event_context_field_type);
 	stream_event_context_type = bt_ctf_field_type_structure_create();
 	bt_ctf_field_type_structure_add_field(stream_event_context_type,
 		integer_type, "common_event_context");


### PR DESCRIPTION
Dynamic scopes of event and stream classes that were previously not initialized are now initialized as empty structures (which are now valid).

This should simplify things for the future.