### PR TITLE
Only compare "bison -y" to the basename of YACC variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,7 @@ AC_CHECK_HEADERS([ \
 ])
 
 if test ! -f "$srcdir/formats/ctf/metadata/ctf-parser.h"; then
-        if test x"$YACC" != "xbison -y"; then
+        if test x"$(basename "$YACC")" != "xbison -y"; then
                 AC_MSG_ERROR([[bison not found and is required when building from git.
                 Please install bison]])
         fi


### PR DESCRIPTION
In the event that the YACC variable is set to a full path
this test fail even if it should not.

Signed-off-by: Jonathan Rajotte <jonathan.rajotte-julien@efficios.com>