### PR TITLE
Add bt_value_map_extend()

### DIFF
--- a/include/babeltrace/values.h
+++ b/include/babeltrace/values.h
@@ -941,6 +941,10 @@ extern enum bt_value_status bt_value_map_insert_empty_array(
 extern enum bt_value_status bt_value_map_insert_empty_map(
 		struct bt_value *map_obj, const char *key);
 
+/* TODO: document */
+extern struct bt_value *bt_value_map_extend(struct bt_value *base_map_obj,
+		struct bt_value *extension_map_obj);
+
 /**
  * Creates a deep copy of the value object \p object.
  *


### PR DESCRIPTION
This new function creates a superficial extension of a base value object by adding new elements to it and replacing the ones that share the keys in the extension object.

For example, consider this base object:

```
hello: 23
code: -17
em: false
return: [5, 6, null]
```

and this extension object:

```
comma: ","
code: 22
return: 17.88
```

The extended object is:

```
hello: 23
code: 22
em: false
return: 17.88
comma: ","
```

The function performs a superficial extension because it does not merge internal arrays and maps. I would create another function for this, e.g. `bt_value_map_extend_deep()`, if ever needed.

The rationale behind `bt_value_map_extend()` is to allow a component to create a map object and fill it with its default parameters, and then extend it with the parameters passed by the user. This can avoid duplicated code like:

```
if user_params.code:
    default_params.code = user_params.code
```

for each individual parameter.
