### PR TITLE
[RFC] Stream intersect bindings

### DIFF
--- a/bindings/python/nativebt.i
+++ b/bindings/python/nativebt.i
@@ -113,6 +113,11 @@ int _bt_python_ctf_clock_get_uuid_index(struct bt_ctf_clock *clock,
 int _bt_python_ctf_clock_set_uuid_index(struct bt_ctf_clock *clock,
 		size_t index, unsigned char value);
 struct bt_iter_pos *_bt_python_create_iter_pos(void);
+struct bt_ctf_iter *_bt_python_ctf_iter_create_intersect(
+	struct bt_context *ctx,
+	struct bt_iter_pos *inter_begin_pos,
+	struct bt_iter_pos *inter_end_pos);
+int _bt_python_has_intersection(struct bt_context *ctx);
 
 /* context.h, context-internal.h */
 %rename("_bt_context_create") bt_context_create(void);

--- a/bindings/python/python-complements.c
+++ b/bindings/python/python-complements.c
@@ -33,6 +33,8 @@
 #include <babeltrace/ctf-ir/event-class.h>
 #include <babeltrace/ctf-ir/clock-internal.h>
 #include <babeltrace/iterator.h>
+#include <babeltrace/ctf/iterator.h>
+#include <babeltrace/ctf/events-internal.h>
 #include <glib.h>
 
 /* List-related functions
@@ -399,4 +401,23 @@ end:
 struct bt_iter_pos *_bt_python_create_iter_pos(void)
 {
 	return g_new0(struct bt_iter_pos, 1);
+}
+
+struct bt_ctf_iter *_bt_python_ctf_iter_create_intersect(
+	struct bt_context *ctx,
+	struct bt_iter_pos *inter_begin_pos,
+	struct bt_iter_pos *inter_end_pos)
+{
+	return bt_ctf_iter_create_intersect(ctx, &inter_begin_pos,
+		&inter_end_pos);
+}
+
+int _bt_python_has_intersection(struct bt_context *ctx)
+{
+	int ret;
+	uint64_t begin = 0, end = ULLONG_MAX;
+
+	ret = ctf_find_packets_intersection(ctx, &begin, &end);
+
+	return ret == 0 ? 1 : 0;
 }

--- a/bindings/python/python-complements.h
+++ b/bindings/python/python-complements.h
@@ -100,3 +100,8 @@ int _bt_python_ctf_clock_set_uuid_index(struct bt_ctf_clock *clock,
 
 /* iterator */
 struct bt_iter_pos *_bt_python_create_iter_pos(void);
+struct bt_ctf_iter *_bt_python_ctf_iter_create_intersect(
+	struct bt_context *ctx,
+	struct bt_iter_pos *inter_begin_pos,
+	struct bt_iter_pos *inter_end_pos);
+int _bt_python_has_intersection(struct bt_context *ctx);

--- a/bindings/python/reader.py
+++ b/bindings/python/reader.py
@@ -45,12 +45,13 @@ class TraceCollection:
     trace from a trace collection.
     """
 
-    def __init__(self):
+    def __init__(self, intersect_mode=False):
         """
         Creates an empty trace collection.
         """
 
         self._tc = nbt._bt_context_create()
+        self.intersect_mode = intersect_mode
 
     def __del__(self):
         nbt._bt_context_put(self._tc)
@@ -147,8 +148,10 @@ class TraceCollection:
 
         begin_pos_ptr = nbt._bt_python_create_iter_pos()
         end_pos_ptr = nbt._bt_python_create_iter_pos()
-        begin_pos_ptr.type = nbt.SEEK_BEGIN
-        end_pos_ptr.type = nbt.SEEK_LAST
+
+        if not self.intersect_mode:
+            begin_pos_ptr.type = nbt.SEEK_BEGIN
+            end_pos_ptr.type = nbt.SEEK_LAST
 
         for event in self._events(begin_pos_ptr, end_pos_ptr):
             yield event
@@ -219,7 +222,18 @@ class TraceCollection:
         return ev.timestamp
 
     def _events(self, begin_pos_ptr, end_pos_ptr):
-        ctf_it_ptr = nbt._bt_ctf_iter_create(self._tc, begin_pos_ptr, end_pos_ptr)
+        if self.intersect_mode:
+            has_intersection = nbt._bt_python_has_intersection(self._tc)
+            if not has_intersection:
+                raise ValueError("No intersection found between trace files.")
+
+            ctf_it_ptr = nbt._bt_python_ctf_iter_create_intersect(
+                self._tc, begin_pos_ptr, end_pos_ptr
+            )
+        else:
+            ctf_it_ptr = nbt._bt_ctf_iter_create(
+                self._tc, begin_pos_ptr, end_pos_ptr
+            )
 
         if ctf_it_ptr is None:
             raise NotImplementedError("Creation of multiple iterators is unsupported.")

--- a/converter/babeltrace.c
+++ b/converter/babeltrace.c
@@ -623,42 +623,6 @@ end:
 }
 
 static
-struct bt_ctf_iter *iter_create_intersect(struct bt_context *ctx,
-		struct bt_iter_pos **inter_begin_pos,
-		struct bt_iter_pos **inter_end_pos)
-{
-	uint64_t begin = 0, end = ULLONG_MAX;
-	int ret;
-
-	ret = ctf_find_packets_intersection(ctx, &begin, &end);
-	if (ret == 1) {
-		fprintf(stderr, "[error] No intersection found between trace files.\n");
-		ret = -1;
-		goto error;
-	} else if (ret != 0) {
-		goto error;
-	}
-	*inter_begin_pos = bt_iter_create_time_pos(NULL, begin);
-	if (!(*inter_begin_pos)) {
-		goto error;
-	}
-	*inter_end_pos = bt_iter_create_time_pos(NULL, end);
-	if (!(*inter_end_pos)) {
-		goto error;
-	}
-
-	/*
-	 * bt_ctf_iter does not take ownership of begin and end positions,
-	 * so we return them to the caller who must still assume their ownership
-	 * until the iterator is destroyed.
-	 */
-	return bt_ctf_iter_create(ctx, *inter_begin_pos,
-			*inter_end_pos);
-error:
-	return NULL;
-}
-
-static
 int convert_trace(struct bt_trace_descriptor *td_write,
 		  struct bt_context *ctx)
 {
@@ -676,7 +640,7 @@ int convert_trace(struct bt_trace_descriptor *td_write,
 	}
 
 	if (opt_stream_intersection) {
-		iter = iter_create_intersect(ctx, &begin_pos, &end_pos);
+		iter = bt_ctf_iter_create_intersect(ctx, &begin_pos, &end_pos);
 	} else {
 		begin_pos = bt_iter_create_time_pos(NULL, 0);
 		begin_pos->type = BT_SEEK_BEGIN;

--- a/include/babeltrace/ctf/iterator.h
+++ b/include/babeltrace/ctf/iterator.h
@@ -63,6 +63,22 @@ struct bt_ctf_iter *bt_ctf_iter_create(struct bt_context *ctx,
 		const struct bt_iter_pos *begin_pos,
 		const struct bt_iter_pos *end_pos);
 
+ /*
+ * bt_ctf_iter_create_intersect - Allocate a CTF trace collection
+ * iterator corresponding to the timerange when all streams are active
+ * simultaneously.
+ *
+ * On success, return a pointer to the newly allocated iterator. The
+ * out parameters inter_begin_pos and inter_end_pos are also set to
+ * correspond to the beginning and end of the intersection,
+ * respectively.
+ *
+ * On failure, return NULL.
+ */
+struct bt_ctf_iter *bt_ctf_iter_create_intersect(struct bt_context *ctx,
+		struct bt_iter_pos **inter_begin_pos,
+		struct bt_iter_pos **inter_end_pos);
+
 /*
  * bt_ctf_get_iter - get iterator from ctf iterator.
  */


### PR DESCRIPTION
Initial implementation of python bindings for stream intersection mode. This adds a function to the `bt_ctf_iter` API, previously located within the converter code, for reuse between the converter and the bindings, as well as an `intersect_mode` attribute to the python class `TraceCollection`. The default behaviour is to set this attribute to `False`, which means existing python code will behave exactly the same. 