### PR TITLE
tests/lib/Makefile.am: remove -static for debug info tests

### DIFF
--- a/tests/lib/Makefile.am
+++ b/tests/lib/Makefile.am
@@ -45,13 +45,11 @@ check_SCRIPTS = test_seek_big_trace \
 		test_ctf_writer_complete
 
 if ENABLE_DEBUG_INFO
-test_dwarf_LDFLAGS = -static
 test_dwarf_LDADD = $(LIBTAP) \
 	$(top_builddir)/lib/libbabeltrace.la \
 	$(top_builddir)/lib/libdebug-info.la
 test_dwarf_SOURCES = test_dwarf.c
 
-test_bin_info_LDFLAGS = -static
 test_bin_info_LDADD = $(LIBTAP) \
 	$(top_builddir)/lib/libbabeltrace.la \
 	$(top_builddir)/lib/libdebug-info.la


### PR DESCRIPTION
This flag is not needed for those tests. It breaks the build when
configuring the project with `--disable-static`.