### PR TITLE
Fix unknown variable name in Python writer

### DIFF
--- a/bindings/python/babeltrace/writer.py
+++ b/bindings/python/babeltrace/writer.py
@@ -1738,7 +1738,7 @@ class Event:
         :exc:`ValueError` is raised on error.
         """
 
-        if not isinstance(value, Field):
+        if not isinstance(value_field, Field):
             raise TypeError("Invalid value type.")
 
         ret = nbt._bt_ctf_event_set_payload(self._e, str(field_name),


### PR DESCRIPTION
Changed variable name 'value' to 'value_field' in order to fix the unknown name error in Python.