### PR TITLE
Build plugins as unversioned modules

### DIFF
--- a/plugins/ctf/Makefile.am
+++ b/plugins/ctf/Makefile.am
@@ -5,23 +5,23 @@ SUBDIRS = common fs-src fs-sink lttng-live
 noinst_HEADERS = print.h
 
 plugindir = "$(PLUGINSDIR)"
-plugin_LTLIBRARIES = libbabeltrace-plugin-ctf.la
+plugin_LTLIBRARIES = babeltrace-plugin-ctf.la
 
 # ctf plugin
-libbabeltrace_plugin_ctf_la_SOURCES = plugin.c
+babeltrace_plugin_ctf_la_SOURCES = plugin.c
 
-libbabeltrace_plugin_ctf_la_LDFLAGS = \
+babeltrace_plugin_ctf_la_LDFLAGS = \
 	$(LT_NO_UNDEFINED) \
-	-version-info $(BABELTRACE_LIBRARY_VERSION)
+	-avoid-version -module -export-dynamic
 
-libbabeltrace_plugin_ctf_la_LIBADD = \
+babeltrace_plugin_ctf_la_LIBADD = \
 	fs-src/libbabeltrace-plugin-ctf-fs.la \
 	lttng-live/libbabeltrace-plugin-ctf-lttng-live.la \
 	fs-sink/libbabeltrace-plugin-ctf-writer.la \
 	common/libbabeltrace-plugin-ctf-common.la
 
 if !BUILT_IN_PLUGINS
-libbabeltrace_plugin_ctf_la_LIBADD += \
+babeltrace_plugin_ctf_la_LIBADD += \
 	$(top_builddir)/lib/libbabeltrace.la \
 	$(top_builddir)/logging/libbabeltrace-logging.la \
 	$(top_builddir)/common/libbabeltrace-common.la

--- a/plugins/lttng-utils/Makefile.am
+++ b/plugins/lttng-utils/Makefile.am
@@ -4,9 +4,9 @@ AM_CFLAGS = $(PACKAGE_CFLAGS) -I$(top_srcdir)/include -I$(top_srcdir)/plugins \
 SUBDIRS = .
 
 plugindir = "$(PLUGINSDIR)"
-plugin_LTLIBRARIES = libbabeltrace-plugin-lttng-utils.la
+plugin_LTLIBRARIES = babeltrace-plugin-lttng-utils.la
 
-libbabeltrace_plugin_lttng_utils_la_SOURCES = \
+babeltrace_plugin_lttng_utils_la_SOURCES = \
 	plugin.c \
 	debug-info.h \
 	debug-info.c \
@@ -24,13 +24,13 @@ libbabeltrace_plugin_lttng_utils_la_SOURCES = \
 	logging.c \
 	logging.h
 
-libbabeltrace_plugin_lttng_utils_la_LDFLAGS = \
+babeltrace_plugin_lttng_utils_la_LDFLAGS = \
 	$(LT_NO_UNDEFINED) \
-	-version-info $(BABELTRACE_LIBRARY_VERSION) \
+	-avoid-version -module -export-dynamic \
 	-lelf -ldw
 
 if !BUILT_IN_PLUGINS
-libbabeltrace_plugin_lttng_utils_la_LIBADD = \
+babeltrace_plugin_lttng_utils_la_LIBADD = \
 	$(top_builddir)/lib/libbabeltrace.la \
 	$(top_builddir)/common/libbabeltrace-common.la \
 	$(top_builddir)/logging/libbabeltrace-logging.la \

--- a/plugins/text/Makefile.am
+++ b/plugins/text/Makefile.am
@@ -3,17 +3,18 @@ AM_CFLAGS = $(PACKAGE_CFLAGS) -I$(top_srcdir)/include -I$(top_srcdir)/plugins
 SUBDIRS = pretty .
 
 plugindir = "$(PLUGINSDIR)"
-plugin_LTLIBRARIES = libbabeltrace-plugin-text.la
+plugin_LTLIBRARIES = babeltrace-plugin-text.la
 
-libbabeltrace_plugin_text_la_SOURCES = plugin.c
-libbabeltrace_plugin_text_la_LDFLAGS = \
+babeltrace_plugin_text_la_SOURCES = plugin.c
+babeltrace_plugin_text_la_LDFLAGS = \
 	$(LT_NO_UNDEFINED) \
-	-version-info $(BABELTRACE_LIBRARY_VERSION)
-libbabeltrace_plugin_text_la_LIBADD = \
+	-avoid-version -module -export-dynamic
+
+babeltrace_plugin_text_la_LIBADD = \
 	pretty/libbabeltrace-plugin-text-pretty-cc.la
 
 if !BUILT_IN_PLUGINS
-libbabeltrace_plugin_text_la_LIBADD += \
+babeltrace_plugin_text_la_LIBADD += \
 	$(top_builddir)/lib/libbabeltrace.la \
 	$(top_builddir)/common/libbabeltrace-common.la \
 	$(top_builddir)/logging/libbabeltrace-logging.la

--- a/plugins/utils/Makefile.am
+++ b/plugins/utils/Makefile.am
@@ -3,18 +3,18 @@ AM_CFLAGS = $(PACKAGE_CFLAGS) -I$(top_srcdir)/include -I$(top_srcdir)/plugins
 SUBDIRS = dummy trimmer muxer .
 
 plugindir = "$(PLUGINSDIR)"
-plugin_LTLIBRARIES = libbabeltrace-plugin-utils.la
+plugin_LTLIBRARIES = babeltrace-plugin-utils.la
 
-libbabeltrace_plugin_utils_la_SOURCES = plugin.c
-libbabeltrace_plugin_utils_la_LDFLAGS = \
+babeltrace_plugin_utils_la_SOURCES = plugin.c
+babeltrace_plugin_utils_la_LDFLAGS = \
 	$(LT_NO_UNDEFINED) \
-	-version-info $(BABELTRACE_LIBRARY_VERSION)
-libbabeltrace_plugin_utils_la_LIBADD = \
+	-avoid-version -module -export-dynamic
+babeltrace_plugin_utils_la_LIBADD = \
 	dummy/libbabeltrace-plugin-dummy-cc.la \
 	trimmer/libbabeltrace-plugin-trimmer.la \
 	muxer/libbabeltrace-plugin-muxer.la
 
 if !BUILT_IN_PLUGINS
-libbabeltrace_plugin_utils_la_LIBADD += \
+babeltrace_plugin_utils_la_LIBADD += \
 	$(top_builddir)/lib/libbabeltrace.la
 endif


### PR DESCRIPTION
This will build the plugins as straight .so file without libtools
'lib' prefix and version symlinks.

See this link for more details :

  https://autotools.io/libtool/plugins.html

Signed-off-by: Michael Jeanson <mjeanson@efficios.com>