### PR TITLE
CTF writer: Drop validation when setting time

### DIFF
--- a/lib/ctf-writer/clock.c
+++ b/lib/ctf-writer/clock.c
@@ -274,12 +274,6 @@ int bt_ctf_clock_set_time(struct bt_ctf_clock *clock, int64_t time)
 		        (double) clock->clock_class->frequency) / 1e9);
 	}
 
-	if (clock->value > value) {
-		/* Timestamps must be strictly monotonic. */
-		ret = -1;
-		goto end;
-	}
-
 	clock->value = value;
 end:
 	return ret;


### PR DESCRIPTION
Fixes bug 1129

When lazily writing events from different streams, the clock
monotonicity is not guaranteed. Checking it globally as it was causes
the faulty event not to be written, though it is fine for its stream.

Signed-off-by: Geneviève Bastien <gbastien@versatic.net>