### PR TITLE
Changes to implement a backward compatible babeltrace package python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,10 +79,6 @@ autom4te.cache/
 config/
 core
 stamp-h1
-bindings/python/__init__.py
-bindings/python/nativebt.py
-bindings/python/nativebt_wrap.c
-bindings/python/bt2/copy-static-deps.stamp
 __pycache__
 babeltrace.pc
 babeltrace-ctf.pc
@@ -93,3 +89,4 @@ doc/api/Doxyfile
 *.gcda
 *.gcov
 *.html
+*.stamp

--- a/bindings/python/bt2/bt2/fields.py
+++ b/bindings/python/bt2/bt2/fields.py
@@ -58,6 +58,15 @@ class _Field(object._Object, metaclass=abc.ABCMeta):
     def field_type(self):
         return self._field_type
 
+    @property
+    def is_set(self):
+        is_set = native_bt.ctf_field_value_is_set(self._ptr)
+        return is_set > 0
+
+    def reset(self):
+        ret = native_bt.ctf_field_reset_value(self._ptr)
+        utils._handle_ret(ret, "cannot reset field object's value")
+
 
 @functools.total_ordering
 class _NumericField(_Field):

--- a/bindings/python/bt2/bt2/fields.py
+++ b/bindings/python/bt2/bt2/fields.py
@@ -655,12 +655,13 @@ class _SequenceField(_ArraySequenceField):
     _NAME = 'Sequence'
 
     def _count(self):
-        return self.length_field.value
+        return int(self.length_field)
 
     @property
     def length_field(self):
         field_ptr = native_bt.ctf_field_sequence_get_length(self._ptr)
-        utils._handle_ptr("cannot get sequence field object's length field")
+        if field_ptr is None:
+            return
         return _create_from_ptr(field_ptr)
 
     @length_field.setter

--- a/bindings/python/bt2/bt2/fields.py
+++ b/bindings/python/bt2/bt2/fields.py
@@ -465,15 +465,8 @@ class _StructureField(_ContainerField, collections.abc.MutableMapping):
         return _create_from_ptr(ptr)
 
     def __setitem__(self, key, value):
-        # we can only set numbers and strings
-        if not isinstance(value, (numbers.Number, str)):
-            raise TypeError('expecting number object or string')
-
-        # raises if index is somehow invalid
+        # raises if key is somehow invalid
         field = self[key]
-
-        if not isinstance(field, (_NumericField, _StringField)):
-            raise TypeError('can only set the value of a number or string field')
 
         # the field's property does the appropriate conversion or raises
         # the appropriate exception

--- a/bindings/python/bt2/bt2/fields.py
+++ b/bindings/python/bt2/bt2/fields.py
@@ -30,6 +30,13 @@ import abc
 import bt2
 
 
+def _get_leaf_field(obj):
+    if type(obj) is not _VariantField:
+        return obj
+
+    return _get_leaf_field(obj.selected_field)
+
+
 def _create_from_ptr(ptr):
     # recreate the field type wrapper of this field's type (the identity
     # could be different, but the underlying address should be the
@@ -53,6 +60,17 @@ class _Field(object._Object, metaclass=abc.ABCMeta):
         cpy = self.__copy__()
         memo[id(self)] = cpy
         return cpy
+
+    def __eq__(self, other):
+        # special case: two unset fields with the same field type are equal
+        if isinstance(other, _Field):
+            if not self.is_set or not other.is_set:
+                if not self.is_set and not other.is_set and self.field_type == other.field_type:
+                    return True
+                return False
+
+        other = _get_leaf_field(other)
+        return self._spec_eq(other)
 
     @property
     def field_type(self):
@@ -87,93 +105,93 @@ class _NumericField(_Field):
         raise TypeError("'{}' object is not a number object".format(other.__class__.__name__))
 
     def __int__(self):
-        return int(self.value)
+        return int(self._value)
 
     def __float__(self):
-        return float(self.value)
+        return float(self._value)
 
     def __str__(self):
-        return str(self.value)
+        return str(self._value)
 
     def __lt__(self, other):
         if not isinstance(other, numbers.Number):
             raise TypeError('unorderable types: {}() < {}()'.format(self.__class__.__name__,
                                                                     other.__class__.__name__))
 
-        return self.value < float(other)
+        return self._value < float(other)
 
     def __le__(self, other):
         if not isinstance(other, numbers.Number):
             raise TypeError('unorderable types: {}() <= {}()'.format(self.__class__.__name__,
                                                                      other.__class__.__name__))
 
-        return self.value <= float(other)
+        return self._value <= float(other)
 
-    def __eq__(self, other):
+    def _spec_eq(self, other):
         if not isinstance(other, numbers.Number):
             return False
 
-        return self.value == complex(other)
+        return self._value == complex(other)
 
     def __rmod__(self, other):
-        return self._extract_value(other) % self.value
+        return self._extract_value(other) % self._value
 
     def __mod__(self, other):
-        return self.value % self._extract_value(other)
+        return self._value % self._extract_value(other)
 
     def __rfloordiv__(self, other):
-        return self._extract_value(other) // self.value
+        return self._extract_value(other) // self._value
 
     def __floordiv__(self, other):
-        return self.value // self._extract_value(other)
+        return self._value // self._extract_value(other)
 
     def __round__(self, ndigits=None):
         if ndigits is None:
-            return round(self.value)
+            return round(self._value)
         else:
-            return round(self.value, ndigits)
+            return round(self._value, ndigits)
 
     def __ceil__(self):
-        return math.ceil(self.value)
+        return math.ceil(self._value)
 
     def __floor__(self):
-        return math.floor(self.value)
+        return math.floor(self._value)
 
     def __trunc__(self):
-        return int(self.value)
+        return int(self._value)
 
     def __abs__(self):
-        return abs(self.value)
+        return abs(self._value)
 
     def __add__(self, other):
-        return self.value + self._extract_value(other)
+        return self._value + self._extract_value(other)
 
     def __radd__(self, other):
         return self.__add__(other)
 
     def __neg__(self):
-        return -self.value
+        return -self._value
 
     def __pos__(self):
-        return +self.value
+        return +self._value
 
     def __mul__(self, other):
-        return self.value * self._extract_value(other)
+        return self._value * self._extract_value(other)
 
     def __rmul__(self, other):
         return self.__mul__(other)
 
     def __truediv__(self, other):
-        return self.value / self._extract_value(other)
+        return self._value / self._extract_value(other)
 
     def __rtruediv__(self, other):
-        return self._extract_value(other) / self.value
+        return self._extract_value(other) / self._value
 
     def __pow__(self, exponent):
-        return self.value ** self._extract_value(exponent)
+        return self._value ** self._extract_value(exponent)
 
     def __rpow__(self, base):
-        return self._extract_value(base) ** self.value
+        return self._extract_value(base) ** self._value
 
     def __iadd__(self, other):
         self.value = self + other
@@ -206,37 +224,37 @@ class _NumericField(_Field):
 
 class _IntegralField(_NumericField, numbers.Integral):
     def __lshift__(self, other):
-        return self.value << self._extract_value(other)
+        return self._value << self._extract_value(other)
 
     def __rlshift__(self, other):
-        return self._extract_value(other) << self.value
+        return self._extract_value(other) << self._value
 
     def __rshift__(self, other):
-        return self.value >> self._extract_value(other)
+        return self._value >> self._extract_value(other)
 
     def __rrshift__(self, other):
-        return self._extract_value(other) >> self.value
+        return self._extract_value(other) >> self._value
 
     def __and__(self, other):
-        return self.value & self._extract_value(other)
+        return self._value & self._extract_value(other)
 
     def __rand__(self, other):
-        return self._extract_value(other) & self.value
+        return self._extract_value(other) & self._value
 
     def __xor__(self, other):
-        return self.value ^ self._extract_value(other)
+        return self._value ^ self._extract_value(other)
 
     def __rxor__(self, other):
-        return self._extract_value(other) ^ self.value
+        return self._extract_value(other) ^ self._value
 
     def __or__(self, other):
-        return self.value | self._extract_value(other)
+        return self._value | self._extract_value(other)
 
     def __ror__(self, other):
-        return self._extract_value(other) | self.value
+        return self._extract_value(other) | self._value
 
     def __invert__(self):
-        return ~self.value
+        return ~self._value
 
     def __ilshift__(self, other):
         self.value = self << other
@@ -280,20 +298,21 @@ class _IntegerField(_IntegralField):
         return value
 
     @property
-    def value(self):
+    def _value(self):
         if self.field_type.is_signed:
             ret, value = native_bt.ctf_field_signed_integer_get_value(self._ptr)
         else:
             ret, value = native_bt.ctf_field_unsigned_integer_get_value(self._ptr)
 
         if ret < 0:
-            # field is not set
-            return
+            if not self.is_set:
+                return
+
+            utils._handle_ret(ret, "cannot get integer field's value")
 
         return value
 
-    @value.setter
-    def value(self, value):
+    def _set_value(self, value):
         value = self._value_to_int(value)
 
         if self.field_type.is_signed:
@@ -303,6 +322,7 @@ class _IntegerField(_IntegralField):
 
         utils._handle_ret(ret, "cannot set integer field object's value")
 
+    value = property(fset=_set_value)
 
 class _FloatingPointNumberField(_RealField):
     _NAME = 'Floating point number'
@@ -314,21 +334,23 @@ class _FloatingPointNumberField(_RealField):
         return float(value)
 
     @property
-    def value(self):
+    def _value(self):
         ret, value = native_bt.ctf_field_floating_point_get_value(self._ptr)
 
         if ret < 0:
-            # field is not set
-            return
+            if not self.is_set:
+                return
+
+            utils._handle_ret(ret, "cannot get floating point number field's value")
 
         return value
 
-    @value.setter
-    def value(self, value):
+    def _set_value(self, value):
         value = self._value_to_float(value)
         ret = native_bt.ctf_field_floating_point_set_value(self._ptr, value)
         utils._handle_ret(ret, "cannot set floating point number field object's value")
 
+    value = property(fset=_set_value)
 
 class _EnumerationField(_IntegerField):
     _NAME = 'Enumeration'
@@ -339,13 +361,14 @@ class _EnumerationField(_IntegerField):
         assert(int_field_ptr)
         return _create_from_ptr(int_field_ptr)
 
-    @property
-    def value(self):
-        return self.integer_field.value
-
-    @value.setter
-    def value(self, value):
+    def _set_value(self, value):
         self.integer_field.value = value
+
+    value = property(fset=_set_value)
+
+    @property
+    def _value(self):
+        return self.integer_field._value
 
     @property
     def mappings(self):
@@ -361,7 +384,7 @@ class _StringField(_Field, collections.abc.Sequence):
 
     def _value_to_str(self, value):
         if isinstance(value, self.__class__):
-            value = value.value
+            value = value._value
 
         if not isinstance(value, str):
             raise TypeError("expecting a 'str' object")
@@ -369,46 +392,42 @@ class _StringField(_Field, collections.abc.Sequence):
         return value
 
     @property
-    def value(self):
+    def _value(self):
         value = native_bt.ctf_field_string_get_value(self._ptr)
-
-        if value is None:
-            # field is not set
-            return
-
         return value
 
-    @value.setter
-    def value(self, value):
+    def _set_value(self, value):
         value = self._value_to_str(value)
         ret = native_bt.ctf_field_string_set_value(self._ptr, value)
         utils._handle_ret(ret, "cannot set string field object's value")
 
-    def __eq__(self, other):
+    value = property(fset=_set_value)
+
+    def _spec_eq(self, other):
         try:
             other = self._value_to_str(other)
         except:
             return False
 
-        return self.value == other
+        return self._value == other
 
     def __le__(self, other):
-        return self.value <= self._value_to_str(other)
+        return self._value <= self._value_to_str(other)
 
     def __lt__(self, other):
-        return self.value < self._value_to_str(other)
+        return self._value < self._value_to_str(other)
 
     def __bool__(self):
-        return bool(self.value)
+        return bool(self._value)
 
     def __str__(self):
-        return self.value
+        return self._value
 
     def __getitem__(self, index):
-        return self.value[index]
+        return self._value[index]
 
     def __len__(self):
-        return len(self.value)
+        return len(self._value)
 
     def __iadd__(self, value):
         value = self._value_to_str(value)
@@ -474,36 +493,39 @@ class _StructureField(_ContainerField, collections.abc.MutableMapping):
         # same name iterator
         return iter(self.field_type)
 
-    def __eq__(self, other):
-        if not isinstance(other, collections.abc.Mapping):
-            return False
-
-        if len(self) != len(other):
-            return False
-
-        for self_key, self_value in self.items():
-            if self_key not in other:
+    def _spec_eq(self, other):
+        try:
+            if len(self) != len(other):
                 return False
 
-            other_value = other[self_key]
+            for self_key, self_value in self.items():
+                if self_key not in other:
+                    return False
 
-            if self_value != other_value:
-                return False
+                other_value = other[self_key]
 
-        return True
+                if self_value != other_value:
+                    return False
+
+            return True
+        except:
+            return False
 
     @property
-    def value(self):
-        return {key: field.value for key, field in self.items()}
+    def _value(self):
+        return {key: value._value for key, value in self.items()}
 
-    @value.setter
-    def value(self, values):
-        if not hasattr(type(values), '__getitem__'):
-            raise TypeError('expecting a Mapping collection')
+    def _set_value(self, values):
+        original_values = self._value
 
-        for key, value in values.items():
-            self[key].value = value
+        try:
+            for key, value in values.items():
+                self[key].value = value
+        except:
+            self.value = original_values
+            raise
 
+    value = property(fset=_set_value)
 
 class _VariantField(_Field):
     _NAME = 'Variant'
@@ -534,18 +556,22 @@ class _VariantField(_Field):
 
         return _create_from_ptr(field_ptr)
 
-    def __eq__(self, other):
-        if type(other) is not type(self):
-            return False
-
-        if self.addr == other.addr:
-            return True
-
-        return self.selected_field == other.selected_field
+    def _spec_eq(self, other):
+        self_field = _get_leaf_field(self)
+        return self_field == other
 
     def __bool__(self):
         return bool(self.selected_field)
 
+    @property
+    def _value(self):
+        if self.selected_field is not None:
+            return self.selected_field._value
+
+    def _set_value(self, value):
+        self.selected_field.value = value
+
+    value = property(fset=_set_value)
 
 class _ArraySequenceField(_ContainerField, collections.abc.MutableSequence):
     def __getitem__(self, index):
@@ -579,33 +605,22 @@ class _ArraySequenceField(_ContainerField, collections.abc.MutableSequence):
     def insert(self, index, value):
         raise NotImplementedError
 
-    def __eq__(self, other):
-        if not isinstance(other, collections.abc.Sequence):
-            return False
-
-        if len(self) != len(other):
-            return False
-
-        for self_field, other_field in zip(self, other):
-            if self_field != other_field:
+    def _spec_eq(self, other):
+        try:
+            if len(self) != len(other):
                 return False
 
-        return True
+            for self_field, other_field in zip(self, other):
+                if self_field != other_field:
+                    return False
+
+            return True
+        except:
+            return False
 
     @property
-    def value(self):
-        return [field.value for field in self]
-
-    @value.setter
-    def value(self, values):
-        if not hasattr(type(values), '__iter__'):
-            raise TypeError('expecting an iterable container (Sequence)')
-
-        if len(self) != len(values):
-            raise ValueError('expected length of value and field to match')
-
-        for index, value in enumerate(values):
-            self[index].value = value
+    def _value(self):
+        return [field._value for field in self]
 
 
 class _ArrayField(_ArraySequenceField):
@@ -616,6 +631,24 @@ class _ArrayField(_ArraySequenceField):
 
     def _get_field_ptr_at_index(self, index):
         return native_bt.ctf_field_array_get_field(self._ptr, index)
+
+    def _set_value(self, values):
+        if len(self) != len(values):
+            raise ValueError(
+                'expected length of value and array field to match')
+
+        original_values = self._value
+        try:
+            for index, value in enumerate(values):
+                if value is not None:
+                    self[index].value = value
+                else:
+                    self[index].reset()
+        except:
+            self.value = original_values
+            raise
+
+    value = property(fset=_set_value)
 
 
 class _SequenceField(_ArraySequenceField):
@@ -639,6 +672,33 @@ class _SequenceField(_ArraySequenceField):
     def _get_field_ptr_at_index(self, index):
         return native_bt.ctf_field_sequence_get_field(self._ptr, index)
 
+    def _set_value(self, values):
+        original_length_field = self.length_field
+        if original_length_field is not None:
+            original_values = self._value
+
+        if len(values) != self.length_field:
+            if self.length_field is not None:
+                length_ft = self.length_field.field_type
+            else:
+                length_ft = bt2.IntegerFieldType(size=64, is_signed=False)
+            self.length_field = length_ft(len(values))
+
+        try:
+            for index, value in enumerate(values):
+                if value is not None:
+                    self[index].value = value
+                else:
+                    self[index].reset()
+        except:
+            if original_length_field is not None:
+                self.length_field = original_length_field
+                self.value = original_values
+            else:
+                self.reset()
+            raise
+
+    value = property(fset=_set_value)
 
 _TYPE_ID_TO_OBJ = {
     native_bt.CTF_FIELD_TYPE_ID_INTEGER: _IntegerField,

--- a/bindings/python/bt2/bt2/fields.py
+++ b/bindings/python/bt2/bt2/fields.py
@@ -483,6 +483,18 @@ class _StructureField(_ContainerField, collections.abc.MutableMapping):
 
         return True
 
+    @property
+    def value(self):
+        return {key: field.value for key, field in self.items()}
+
+    @value.setter
+    def value(self, values):
+        if not hasattr(type(values), '__getitem__'):
+            raise TypeError('expecting a Mapping collection')
+
+        for key, value in values.items():
+            self[key].value = value
+
 
 class _VariantField(_Field):
     _NAME = 'Variant'
@@ -570,6 +582,21 @@ class _ArraySequenceField(_ContainerField, collections.abc.MutableSequence):
                 return False
 
         return True
+
+    @property
+    def value(self):
+        return [field.value for field in self]
+
+    @value.setter
+    def value(self, values):
+        if not hasattr(type(values), '__iter__'):
+            raise TypeError('expecting an iterable container (Sequence)')
+
+        if len(self) != len(values):
+            raise ValueError('expected length of value and field to match')
+
+        for index, value in enumerate(values):
+            self[index].value = value
 
 
 class _ArrayField(_ArraySequenceField):

--- a/bindings/python/bt2/bt2/native_btfields.i
+++ b/bindings/python/bt2/bt2/native_btfields.i
@@ -31,6 +31,8 @@ struct bt_ctf_field *bt_ctf_field_create(
 struct bt_ctf_field_type *bt_ctf_field_get_type(
 		struct bt_ctf_field *field);
 struct bt_ctf_field *bt_ctf_field_copy(struct bt_ctf_field *field);
+bt_bool bt_ctf_field_value_is_set(struct bt_ctf_field *field);
+int bt_ctf_field_reset_value(struct bt_ctf_field *field);
 
 /* Integer field functions */
 int bt_ctf_field_signed_integer_get_value(struct bt_ctf_field *integer,

--- a/include/babeltrace/ctf-ir/fields-internal.h
+++ b/include/babeltrace/ctf-ir/fields-internal.h
@@ -65,7 +65,6 @@ struct bt_ctf_field_floating_point {
 
 struct bt_ctf_field_structure {
 	struct bt_ctf_field parent;
-	GHashTable *field_name_to_index;
 	GPtrArray *fields; /* Array of pointers to struct bt_ctf_field */
 };
 

--- a/include/babeltrace/ctf-ir/fields-internal.h
+++ b/include/babeltrace/ctf-ir/fields-internal.h
@@ -94,10 +94,6 @@ struct bt_ctf_field_string {
 BT_HIDDEN
 int bt_ctf_field_validate(struct bt_ctf_field *field);
 
-/* Mark field payload as unset. */
-BT_HIDDEN
-int bt_ctf_field_reset(struct bt_ctf_field *field);
-
 BT_HIDDEN
 int bt_ctf_field_serialize(struct bt_ctf_field *field,
 		struct bt_ctf_stream_pos *pos,
@@ -105,8 +101,5 @@ int bt_ctf_field_serialize(struct bt_ctf_field *field,
 
 BT_HIDDEN
 void bt_ctf_field_freeze(struct bt_ctf_field *field);
-
-BT_HIDDEN
-bt_bool bt_ctf_field_is_set(struct bt_ctf_field *field);
 
 #endif /* BABELTRACE_CTF_IR_FIELDS_INTERNAL_H */

--- a/include/babeltrace/ctf-ir/fields-internal.h
+++ b/include/babeltrace/ctf-ir/fields-internal.h
@@ -33,6 +33,7 @@
 #include <babeltrace/babeltrace-internal.h>
 #include <babeltrace/types.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <glib.h>
 
 struct bt_ctf_stream_pos;
@@ -40,8 +41,8 @@ struct bt_ctf_stream_pos;
 struct bt_ctf_field {
 	struct bt_object base;
 	struct bt_ctf_field_type *type;
-	int payload_set;
-	int frozen;
+	bool payload_set;
+	bool frozen;
 };
 
 struct bt_ctf_field_integer {

--- a/include/babeltrace/ctf-ir/fields.h
+++ b/include/babeltrace/ctf-ir/fields.h
@@ -907,8 +907,9 @@ extern struct bt_ctf_field *bt_ctf_field_structure_get_field_by_index(
 @brief	Sets the field of the @structfield \p struct_field named \p name
 	to the @field \p field.
 
-If \p struct_field already contains a field named \p name, then its
-reference count is decremented, and \p field replaces it.
+If \p struct_field already contains a field named \p name, then it may
+either be replaced by \p field and its reference count is decremented,
+or \p field's value is assigned to it.
 
 The field type of \p field, as returned by bt_ctf_field_get_type(),
 \em must be equivalent to the field type returned by
@@ -933,9 +934,8 @@ bt_ctf_trace_get_packet_header_type() for the parent trace class of
 	bt_ctf_field_type_structure_get_field_type_by_name() for the
 	field type of \p struct_field with the name \p name.
 @postrefcountsame{struct_field}
-@post <strong>On success, if there's an existing field in
-	\p struct_field named \p name</strong>, its reference count is
-	decremented.
+@post <strong>On success, the field in \p struct_field named \p name</strong>
+	may either be replaced by \p field or have the same value as \p field.
 @postsuccessrefcountinc{field}
 
 @sa bt_ctf_field_structure_get_field_by_index(): Returns the field of a

--- a/include/babeltrace/ctf-ir/fields.h
+++ b/include/babeltrace/ctf-ir/fields.h
@@ -213,7 +213,13 @@ extern struct bt_ctf_field_type *bt_ctf_field_get_type(
 @sa bt_ctf_field_is_variant(): Returns whether or not a given field is a
 	@varfield.
 */
-extern enum bt_ctf_field_type_id bt_ctf_field_get_type_id(struct bt_ctf_field *field);
+extern enum bt_ctf_field_type_id bt_ctf_field_get_type_id(
+		struct bt_ctf_field *field);
+
+
+extern bt_bool bt_ctf_field_value_is_set(struct bt_ctf_field *field);
+
+extern int bt_ctf_field_reset_value(struct bt_ctf_field *field);
 
 /*
  * bt_ctf_field_signed_integer_get_value: get a signed integer field's value

--- a/lib/ctf-ir/fields.c
+++ b/lib/ctf-ir/fields.c
@@ -492,7 +492,7 @@ int bt_ctf_field_sequence_set_length(struct bt_ctf_field *field,
 		bt_put(sequence->length);
 	}
 
-	sequence->elements = g_ptr_array_sized_new((size_t)sequence_length);
+	sequence->elements = g_ptr_array_sized_new((size_t) sequence_length);
 	if (!sequence->elements) {
 		BT_LOGE_STR("Failed to allocate a GPtrArray.");
 		ret = -1;

--- a/lib/ctf-ir/fields.c
+++ b/lib/ctf-ir/fields.c
@@ -3169,7 +3169,8 @@ bt_bool bt_ctf_field_structure_value_is_set(struct bt_ctf_field *field)
 
 	structure = container_of(field, struct bt_ctf_field_structure, parent);
 	for (i = 0; i < structure->fields->len; i++) {
-		value_is_set = bt_ctf_field_value_is_set(structure->fields->pdata[i]);
+		value_is_set = bt_ctf_field_value_is_set(
+			structure->fields->pdata[i]);
 		if (!value_is_set) {
 			goto end;
 		}

--- a/lib/ctf-ir/fields.c
+++ b/lib/ctf-ir/fields.c
@@ -1264,7 +1264,7 @@ int bt_ctf_field_signed_integer_set_value(struct bt_ctf_field *field,
 	}
 
 	integer->payload.signd = value;
-	integer->parent.payload_set = 1;
+	integer->parent.payload_set = true;
 end:
 	return ret;
 }
@@ -1374,7 +1374,7 @@ int bt_ctf_field_unsigned_integer_set_value(struct bt_ctf_field *field,
 	}
 
 	integer->payload.unsignd = value;
-	integer->parent.payload_set = 1;
+	integer->parent.payload_set = true;
 end:
 	return ret;
 }
@@ -1452,7 +1452,7 @@ int bt_ctf_field_floating_point_set_value(struct bt_ctf_field *field,
 	floating_point = container_of(field, struct bt_ctf_field_floating_point,
 		parent);
 	floating_point->payload = value;
-	floating_point->parent.payload_set = 1;
+	floating_point->parent.payload_set = true;
 end:
 	return ret;
 }
@@ -1530,7 +1530,7 @@ int bt_ctf_field_string_set_value(struct bt_ctf_field *field,
 		string->payload = g_string_new(value);
 	}
 
-	string->parent.payload_set = 1;
+	string->parent.payload_set = true;
 end:
 	return ret;
 }
@@ -1578,7 +1578,7 @@ int bt_ctf_field_string_append(struct bt_ctf_field *field,
 		string_field->payload = g_string_new(value);
 	}
 
-	string_field->parent.payload_set = 1;
+	string_field->parent.payload_set = true;
 
 end:
 	return ret;
@@ -1639,7 +1639,7 @@ int bt_ctf_field_string_append_len(struct bt_ctf_field *field,
 			effective_length);
 	}
 
-	string_field->parent.payload_set = 1;
+	string_field->parent.payload_set = true;
 
 end:
 	return ret;
@@ -2269,7 +2269,7 @@ int bt_ctf_field_generic_reset(struct bt_ctf_field *field)
 		goto end;
 	}
 
-	field->payload_set = 0;
+	field->payload_set = false;
 end:
 	return ret;
 }
@@ -3074,7 +3074,7 @@ end:
 static
 void generic_field_freeze(struct bt_ctf_field *field)
 {
-	field->frozen = 1;
+	field->frozen = true;
 }
 
 static

--- a/lib/ctf-ir/fields.c
+++ b/lib/ctf-ir/fields.c
@@ -483,6 +483,15 @@ int bt_ctf_field_sequence_set_length(struct bt_ctf_field *field,
 		goto end;
 	}
 
+	if (!bt_ctf_field_value_is_set(length_field)) {
+		BT_LOGW("Invalid parameter: length field's value is not set: "
+			"field-addr=%p, length-field-addr=%p, "
+			"length-field-ft-addr=%p", field, length_field,
+			length_field->type);
+		ret = -1;
+		goto end;
+	}
+
 	length = container_of(length_field, struct bt_ctf_field_integer,
 		parent);
 	sequence_length = length->payload.unsignd;
@@ -504,6 +513,7 @@ int bt_ctf_field_sequence_set_length(struct bt_ctf_field *field,
 	g_ptr_array_set_size(sequence->elements, (size_t) sequence_length);
 	bt_get(length_field);
 	sequence->length = length_field;
+	bt_ctf_field_freeze(length_field);
 end:
 	return ret;
 }

--- a/lib/ctf-ir/fields.c
+++ b/lib/ctf-ir/fields.c
@@ -95,19 +95,19 @@ static
 int bt_ctf_field_sequence_validate(struct bt_ctf_field *);
 
 static
-int bt_ctf_field_generic_reset(struct bt_ctf_field *);
+int bt_ctf_field_generic_reset_value(struct bt_ctf_field *);
 static
-int bt_ctf_field_structure_reset(struct bt_ctf_field *);
+int bt_ctf_field_structure_reset_value(struct bt_ctf_field *);
 static
-int bt_ctf_field_variant_reset(struct bt_ctf_field *);
+int bt_ctf_field_variant_reset_value(struct bt_ctf_field *);
 static
-int bt_ctf_field_enumeration_reset(struct bt_ctf_field *);
+int bt_ctf_field_enumeration_reset_value(struct bt_ctf_field *);
 static
-int bt_ctf_field_array_reset(struct bt_ctf_field *);
+int bt_ctf_field_array_reset_value(struct bt_ctf_field *);
 static
-int bt_ctf_field_sequence_reset(struct bt_ctf_field *);
+int bt_ctf_field_sequence_reset_value(struct bt_ctf_field *);
 static
-int bt_ctf_field_string_reset(struct bt_ctf_field *);
+int bt_ctf_field_string_reset_value(struct bt_ctf_field *);
 
 static
 int bt_ctf_field_integer_serialize(struct bt_ctf_field *,
@@ -166,17 +166,17 @@ static
 void bt_ctf_field_sequence_freeze(struct bt_ctf_field *);
 
 static
-bt_bool bt_ctf_field_generic_is_set(struct bt_ctf_field *);
+bt_bool bt_ctf_field_generic_value_is_set(struct bt_ctf_field *);
 static
-bt_bool bt_ctf_field_structure_is_set(struct bt_ctf_field *);
+bt_bool bt_ctf_field_structure_value_is_set(struct bt_ctf_field *);
 static
-bt_bool bt_ctf_field_variant_is_set(struct bt_ctf_field *);
+bt_bool bt_ctf_field_variant_value_is_set(struct bt_ctf_field *);
 static
-bt_bool bt_ctf_field_enumeration_is_set(struct bt_ctf_field *);
+bt_bool bt_ctf_field_enumeration_value_is_set(struct bt_ctf_field *);
 static
-bt_bool bt_ctf_field_array_is_set(struct bt_ctf_field *);
+bt_bool bt_ctf_field_array_value_is_set(struct bt_ctf_field *);
 static
-bt_bool bt_ctf_field_sequence_is_set(struct bt_ctf_field *);
+bt_bool bt_ctf_field_sequence_value_is_set(struct bt_ctf_field *);
 
 static
 int increase_packet_size(struct bt_ctf_stream_pos *pos);
@@ -221,15 +221,15 @@ int (* const field_validate_funcs[])(struct bt_ctf_field *) = {
 };
 
 static
-int (* const field_reset_funcs[])(struct bt_ctf_field *) = {
-	[BT_CTF_FIELD_TYPE_ID_INTEGER] = bt_ctf_field_generic_reset,
-	[BT_CTF_FIELD_TYPE_ID_ENUM] = bt_ctf_field_enumeration_reset,
-	[BT_CTF_FIELD_TYPE_ID_FLOAT] = bt_ctf_field_generic_reset,
-	[BT_CTF_FIELD_TYPE_ID_STRUCT] = bt_ctf_field_structure_reset,
-	[BT_CTF_FIELD_TYPE_ID_VARIANT] = bt_ctf_field_variant_reset,
-	[BT_CTF_FIELD_TYPE_ID_ARRAY] = bt_ctf_field_array_reset,
-	[BT_CTF_FIELD_TYPE_ID_SEQUENCE] = bt_ctf_field_sequence_reset,
-	[BT_CTF_FIELD_TYPE_ID_STRING] = bt_ctf_field_string_reset,
+int (* const field_reset_value_funcs[])(struct bt_ctf_field *) = {
+	[BT_CTF_FIELD_TYPE_ID_INTEGER] = bt_ctf_field_generic_reset_value,
+	[BT_CTF_FIELD_TYPE_ID_ENUM] = bt_ctf_field_enumeration_reset_value,
+	[BT_CTF_FIELD_TYPE_ID_FLOAT] = bt_ctf_field_generic_reset_value,
+	[BT_CTF_FIELD_TYPE_ID_STRUCT] = bt_ctf_field_structure_reset_value,
+	[BT_CTF_FIELD_TYPE_ID_VARIANT] = bt_ctf_field_variant_reset_value,
+	[BT_CTF_FIELD_TYPE_ID_ARRAY] = bt_ctf_field_array_reset_value,
+	[BT_CTF_FIELD_TYPE_ID_SEQUENCE] = bt_ctf_field_sequence_reset_value,
+	[BT_CTF_FIELD_TYPE_ID_STRING] = bt_ctf_field_string_reset_value,
 };
 
 static
@@ -272,15 +272,15 @@ void (* const field_freeze_funcs[])(struct bt_ctf_field *) = {
 };
 
 static
-bt_bool (* const field_is_set_funcs[])(struct bt_ctf_field *) = {
-	[BT_CTF_FIELD_TYPE_ID_INTEGER] = bt_ctf_field_generic_is_set,
-	[BT_CTF_FIELD_TYPE_ID_ENUM] = bt_ctf_field_enumeration_is_set,
-	[BT_CTF_FIELD_TYPE_ID_FLOAT] = bt_ctf_field_generic_is_set,
-	[BT_CTF_FIELD_TYPE_ID_STRUCT] = bt_ctf_field_structure_is_set,
-	[BT_CTF_FIELD_TYPE_ID_VARIANT] = bt_ctf_field_variant_is_set,
-	[BT_CTF_FIELD_TYPE_ID_ARRAY] = bt_ctf_field_array_is_set,
-	[BT_CTF_FIELD_TYPE_ID_SEQUENCE] = bt_ctf_field_sequence_is_set,
-	[BT_CTF_FIELD_TYPE_ID_STRING] = bt_ctf_field_generic_is_set,
+bt_bool (* const field_value_is_set_funcs[])(struct bt_ctf_field *) = {
+	[BT_CTF_FIELD_TYPE_ID_INTEGER] = bt_ctf_field_generic_value_is_set,
+	[BT_CTF_FIELD_TYPE_ID_ENUM] = bt_ctf_field_enumeration_value_is_set,
+	[BT_CTF_FIELD_TYPE_ID_FLOAT] = bt_ctf_field_generic_value_is_set,
+	[BT_CTF_FIELD_TYPE_ID_STRUCT] = bt_ctf_field_structure_value_is_set,
+	[BT_CTF_FIELD_TYPE_ID_VARIANT] = bt_ctf_field_variant_value_is_set,
+	[BT_CTF_FIELD_TYPE_ID_ARRAY] = bt_ctf_field_array_value_is_set,
+	[BT_CTF_FIELD_TYPE_ID_SEQUENCE] = bt_ctf_field_sequence_value_is_set,
+	[BT_CTF_FIELD_TYPE_ID_STRING] = bt_ctf_field_generic_value_is_set,
 };
 
 struct bt_ctf_field *bt_ctf_field_create(struct bt_ctf_field_type *type)
@@ -1598,14 +1598,20 @@ end:
 	return ret;
 }
 
-BT_HIDDEN
-int bt_ctf_field_reset(struct bt_ctf_field *field)
+int bt_ctf_field_reset_value(struct bt_ctf_field *field)
 {
 	int ret = 0;
 	enum bt_ctf_field_type_id type_id;
 
 	if (!field) {
 		BT_LOGD_STR("Invalid parameter: field is NULL.");
+		ret = -1;
+		goto end;
+	}
+
+	if (field->frozen) {
+		BT_LOGW("Invalid parameter: field is frozen: addr=%p",
+			field);
 		ret = -1;
 		goto end;
 	}
@@ -1619,7 +1625,7 @@ int bt_ctf_field_reset(struct bt_ctf_field *field)
 		goto end;
 	}
 
-	ret = field_reset_funcs[type_id](field);
+	ret = field_reset_value_funcs[type_id](field);
 end:
 	return ret;
 }
@@ -1654,11 +1660,9 @@ end:
 	return ret;
 }
 
-
-BT_HIDDEN
-bt_bool bt_ctf_field_is_set(struct bt_ctf_field *field)
+bt_bool bt_ctf_field_value_is_set(struct bt_ctf_field *field)
 {
-	bt_bool is_set = BT_FALSE;
+	bt_bool value_is_set = BT_FALSE;
 	enum bt_ctf_field_type_id type_id;
 
 	if (!field) {
@@ -1673,9 +1677,9 @@ bt_bool bt_ctf_field_is_set(struct bt_ctf_field *field)
 		goto end;
 	}
 
-	is_set = field_is_set_funcs[type_id](field);
+	value_is_set = field_value_is_set_funcs[type_id](field);
 end:
-	return is_set;
+	return value_is_set;
 }
 
 struct bt_ctf_field *bt_ctf_field_copy(struct bt_ctf_field *field)
@@ -2204,7 +2208,7 @@ end:
 }
 
 static
-int bt_ctf_field_generic_reset(struct bt_ctf_field *field)
+int bt_ctf_field_generic_reset_value(struct bt_ctf_field *field)
 {
 	int ret = 0;
 
@@ -2220,7 +2224,7 @@ end:
 }
 
 static
-int bt_ctf_field_enumeration_reset(struct bt_ctf_field *field)
+int bt_ctf_field_enumeration_reset_value(struct bt_ctf_field *field)
 {
 	int ret = 0;
 	struct bt_ctf_field_enumeration *enumeration;
@@ -2237,13 +2241,13 @@ int bt_ctf_field_enumeration_reset(struct bt_ctf_field *field)
 		goto end;
 	}
 
-	ret = bt_ctf_field_reset(enumeration->payload);
+	ret = bt_ctf_field_reset_value(enumeration->payload);
 end:
 	return ret;
 }
 
 static
-int bt_ctf_field_structure_reset(struct bt_ctf_field *field)
+int bt_ctf_field_structure_reset_value(struct bt_ctf_field *field)
 {
 	int64_t i;
 	int ret = 0;
@@ -2267,7 +2271,7 @@ int bt_ctf_field_structure_reset(struct bt_ctf_field *field)
 			continue;
 		}
 
-		ret = bt_ctf_field_reset(member);
+		ret = bt_ctf_field_reset_value(member);
 		if (ret) {
 			BT_LOGE("Failed to reset structure field's field: "
 				"struct-field-addr=%p, field-addr=%p, "
@@ -2280,7 +2284,7 @@ end:
 }
 
 static
-int bt_ctf_field_variant_reset(struct bt_ctf_field *field)
+int bt_ctf_field_variant_reset_value(struct bt_ctf_field *field)
 {
 	int ret = 0;
 	struct bt_ctf_field_variant *variant;
@@ -2292,20 +2296,14 @@ int bt_ctf_field_variant_reset(struct bt_ctf_field *field)
 	}
 
 	variant = container_of(field, struct bt_ctf_field_variant, parent);
-	if (variant->payload) {
-		ret = bt_ctf_field_reset(variant->payload);
-		if (ret) {
-			BT_LOGW("Failed to reset variant field's payload field: "
-				"variant-field-addr=%p, payload-field-addr=%p",
-				field, variant->payload);
-		}
-	}
+	BT_PUT(variant->tag);
+	BT_PUT(variant->payload);
 end:
 	return ret;
 }
 
 static
-int bt_ctf_field_array_reset(struct bt_ctf_field *field)
+int bt_ctf_field_array_reset_value(struct bt_ctf_field *field)
 {
 	size_t i;
 	int ret = 0;
@@ -2329,7 +2327,7 @@ int bt_ctf_field_array_reset(struct bt_ctf_field *field)
 			continue;
 		}
 
-		ret = bt_ctf_field_reset(member);
+		ret = bt_ctf_field_reset_value(member);
 		if (ret) {
 			BT_LOGE("Failed to reset array field's field: "
 				"array-field-addr=%p, field-addr=%p, "
@@ -2342,9 +2340,8 @@ end:
 }
 
 static
-int bt_ctf_field_sequence_reset(struct bt_ctf_field *field)
+int bt_ctf_field_sequence_reset_value(struct bt_ctf_field *field)
 {
-	size_t i;
 	int ret = 0;
 	struct bt_ctf_field_sequence *sequence;
 
@@ -2355,31 +2352,17 @@ int bt_ctf_field_sequence_reset(struct bt_ctf_field *field)
 	}
 
 	sequence = container_of(field, struct bt_ctf_field_sequence, parent);
-	for (i = 0; i < sequence->elements->len; i++) {
-		struct bt_ctf_field *member = sequence->elements->pdata[i];
-
-		if (!member) {
-			/*
-			 * Sequence elements are lazily initialized; skip if
-			 * this member has not been allocated yet.
-			 */
-			continue;
-		}
-
-		ret = bt_ctf_field_reset(member);
-		if (ret) {
-			BT_LOGE("Failed to reset sequence field's field: "
-				"sequence-field-addr=%p, field-addr=%p, "
-				"index=%zu", field, member, i);
-			goto end;
-		}
+	if (sequence->elements) {
+		g_ptr_array_free(sequence->elements, TRUE);
+		sequence->elements = NULL;
 	}
+	BT_PUT(sequence->length);
 end:
 	return ret;
 }
 
 static
-int bt_ctf_field_string_reset(struct bt_ctf_field *field)
+int bt_ctf_field_string_reset_value(struct bt_ctf_field *field)
 {
 	int ret = 0;
 	struct bt_ctf_field_string *string;
@@ -2390,7 +2373,7 @@ int bt_ctf_field_string_reset(struct bt_ctf_field *field)
 		goto end;
 	}
 
-	ret = bt_ctf_field_generic_reset(field);
+	ret = bt_ctf_field_generic_reset_value(field);
 	if (ret) {
 		goto end;
 	}
@@ -2416,7 +2399,7 @@ int bt_ctf_field_integer_serialize(struct bt_ctf_field *field,
 		"native-bo=%s", field, pos->offset,
 		bt_ctf_byte_order_string(native_byte_order));
 
-	if (!bt_ctf_field_generic_is_set(field)) {
+	if (!bt_ctf_field_generic_value_is_set(field)) {
 		BT_LOGW_STR("Field's payload is not set.");
 		ret = -1;
 		goto end;
@@ -2468,7 +2451,7 @@ int bt_ctf_field_floating_point_serialize(struct bt_ctf_field *field,
 		"native-bo=%s", field, pos->offset,
 		bt_ctf_byte_order_string(native_byte_order));
 
-	if (!bt_ctf_field_generic_is_set(field)) {
+	if (!bt_ctf_field_generic_value_is_set(field)) {
 		BT_LOGW_STR("Field's payload is not set.");
 		ret = -1;
 		goto end;
@@ -3137,15 +3120,15 @@ end:
 }
 
 static
-bt_bool bt_ctf_field_generic_is_set(struct bt_ctf_field *field)
+bt_bool bt_ctf_field_generic_value_is_set(struct bt_ctf_field *field)
 {
 	return field && field->payload_set;
 }
 
 static
-bt_bool bt_ctf_field_enumeration_is_set(struct bt_ctf_field *field)
+bt_bool bt_ctf_field_enumeration_value_is_set(struct bt_ctf_field *field)
 {
-	bt_bool is_set = BT_FALSE;
+	bt_bool value_is_set = BT_FALSE;
 	struct bt_ctf_field_enumeration *enumeration;
 
 	if (!field) {
@@ -3158,15 +3141,15 @@ bt_bool bt_ctf_field_enumeration_is_set(struct bt_ctf_field *field)
 		goto end;
 	}
 
-	is_set = bt_ctf_field_is_set(enumeration->payload);
+	value_is_set = bt_ctf_field_value_is_set(enumeration->payload);
 end:
-	return is_set;
+	return value_is_set;
 }
 
 static
-bt_bool bt_ctf_field_structure_is_set(struct bt_ctf_field *field)
+bt_bool bt_ctf_field_structure_value_is_set(struct bt_ctf_field *field)
 {
-	bt_bool is_set = BT_FALSE;
+	bt_bool value_is_set = BT_FALSE;
 	size_t i;
 	struct bt_ctf_field_structure *structure;
 
@@ -3176,19 +3159,19 @@ bt_bool bt_ctf_field_structure_is_set(struct bt_ctf_field *field)
 
 	structure = container_of(field, struct bt_ctf_field_structure, parent);
 	for (i = 0; i < structure->fields->len; i++) {
-		is_set = bt_ctf_field_is_set(structure->fields->pdata[i]);
-		if (!is_set) {
+		value_is_set = bt_ctf_field_value_is_set(structure->fields->pdata[i]);
+		if (!value_is_set) {
 			goto end;
 		}
 	}
 end:
-	return is_set;
+	return value_is_set;
 }
 
 static
-bt_bool bt_ctf_field_variant_is_set(struct bt_ctf_field *field)
+bt_bool bt_ctf_field_variant_value_is_set(struct bt_ctf_field *field)
 {
-	bt_bool is_set = BT_FALSE;
+	bt_bool value_is_set = BT_FALSE;
 	struct bt_ctf_field_variant *variant;
 
 	if (!field) {
@@ -3196,16 +3179,16 @@ bt_bool bt_ctf_field_variant_is_set(struct bt_ctf_field *field)
 	}
 
 	variant = container_of(field, struct bt_ctf_field_variant, parent);
-	is_set = bt_ctf_field_is_set(variant->payload);
+	value_is_set = bt_ctf_field_value_is_set(variant->payload);
 end:
-	return is_set;
+	return value_is_set;
 }
 
 static
-bt_bool bt_ctf_field_array_is_set(struct bt_ctf_field *field)
+bt_bool bt_ctf_field_array_value_is_set(struct bt_ctf_field *field)
 {
 	size_t i;
-	bt_bool is_set = BT_FALSE;
+	bt_bool value_is_set = BT_FALSE;
 	struct bt_ctf_field_array *array;
 
 	if (!field) {
@@ -3214,20 +3197,20 @@ bt_bool bt_ctf_field_array_is_set(struct bt_ctf_field *field)
 
 	array = container_of(field, struct bt_ctf_field_array, parent);
 	for (i = 0; i < array->elements->len; i++) {
-		is_set = bt_ctf_field_is_set(array->elements->pdata[i]);
-		if (!is_set) {
+		value_is_set = bt_ctf_field_value_is_set(array->elements->pdata[i]);
+		if (!value_is_set) {
 			goto end;
 		}
 	}
 end:
-	return is_set;
+	return value_is_set;
 }
 
 static
-bt_bool bt_ctf_field_sequence_is_set(struct bt_ctf_field *field)
+bt_bool bt_ctf_field_sequence_value_is_set(struct bt_ctf_field *field)
 {
 	size_t i;
-	bt_bool is_set = BT_FALSE;
+	bt_bool value_is_set = BT_FALSE;
 	struct bt_ctf_field_sequence *sequence;
 
 	if (!field) {
@@ -3235,12 +3218,16 @@ bt_bool bt_ctf_field_sequence_is_set(struct bt_ctf_field *field)
 	}
 
 	sequence = container_of(field, struct bt_ctf_field_sequence, parent);
+	if (!sequence->elements) {
+		goto end;
+	}
+
 	for (i = 0; i < sequence->elements->len; i++) {
-		is_set = bt_ctf_field_validate(sequence->elements->pdata[i]);
-		if (!is_set) {
+		value_is_set = bt_ctf_field_value_is_set(sequence->elements->pdata[i]);
+		if (!value_is_set) {
 			goto end;
 		}
 	}
 end:
-	return is_set;
+	return value_is_set;
 }

--- a/lib/ctf-ir/stream.c
+++ b/lib/ctf-ir/stream.c
@@ -360,7 +360,7 @@ int set_packet_context_events_discarded(struct bt_ctf_stream *stream)
 	 * discarded events. We do not allow wrapping here. If it's
 	 * valid, update the stream's current count.
 	 */
-	if (bt_ctf_field_is_set(field)) {
+	if (bt_ctf_field_value_is_set(field)) {
 		uint64_t user_val;
 
 		ret = bt_ctf_field_unsigned_integer_get_value(field,
@@ -1494,7 +1494,7 @@ void reset_structure_field(struct bt_ctf_field *structure, const char *name)
 
 	member = bt_ctf_field_structure_get_field(structure, name);
 	if (member) {
-		(void) bt_ctf_field_reset(member);
+		(void) bt_ctf_field_reset_value(member);
 		bt_put(member);
 	}
 }
@@ -1873,7 +1873,7 @@ int _set_structure_field_integer(struct bt_ctf_field *structure, char *name,
 	}
 
 	/* Make sure the payload has not already been set. */
-	if (!force && bt_ctf_field_is_set(integer)) {
+	if (!force && bt_ctf_field_value_is_set(integer)) {
 		/* Payload already set, not an error */
 		BT_LOGV("Field's payload is already set: struct-field-addr=%p, "
 			"name=\"%s\", force=%d", structure, name, force);

--- a/tests/bindings/python/bt2/test_event.py
+++ b/tests/bindings/python/bt2/test_event.py
@@ -241,7 +241,7 @@ class EventTestCase(unittest.TestCase):
         tc.add_clock_class(cc)
         ev = self._ec()
         self._fill_ev(ev)
-        ev.clock_value(cc, 234)
+        ev.add_clock_value(cc(234))
         return ev
 
     def test_getitem(self):

--- a/tests/bindings/python/bt2/test_fields.py
+++ b/tests/bindings/python/bt2/test_fields.py
@@ -915,11 +915,6 @@ class StringFieldTestCase(_TestCopySimple, unittest.TestCase):
         with self.assertRaises(TypeError):
             self._def.value = 283
 
-    def test_assign_str(self):
-        raw = 'zorg'
-        self._def = raw
-        self.assertEqual(self._def, raw)
-
     def test_assign_string_field(self):
         ft = bt2.StringFieldType()
         field = ft()

--- a/tests/bindings/python/bt2/test_fields.py
+++ b/tests/bindings/python/bt2/test_fields.py
@@ -1356,7 +1356,8 @@ class StructureFieldTestCase(_TestCopySimple, unittest.TestCase):
         struct_ft.append_field('A', elem_ft)
         struct_field = struct_ft()
 
-        with self.assertRaises(TypeError):
+        # Will fail on access to .items() of the value
+        with self.assertRaises(AttributeError):
             struct_field['A'] = 23
 
     def test_setitem_none(self):

--- a/tests/bindings/python/bt2/test_fields.py
+++ b/tests/bindings/python/bt2/test_fields.py
@@ -516,6 +516,23 @@ class _TestNumericField(_TestCopySimple):
     def test_ne_none(self):
         self.assertTrue(self._def != None)
 
+    def test_is_set(self):
+        raw = self._def_value
+        field = self._ft()
+        self.assertFalse(field.is_set)
+        field.value = raw
+        self.assertTrue(field.is_set)
+
+    def test_reset(self):
+        raw = self._def_value
+        field = self._ft()
+        field.value = raw
+        self.assertTrue(field.is_set)
+        field.reset()
+        self.assertFalse(field.is_set)
+        other = self._ft()
+        self.assertEqual(other, field)
+
 
 _BINOPS = (
     ('lt', operator.lt),
@@ -1003,6 +1020,23 @@ class StringFieldTestCase(_TestCopySimple, unittest.TestCase):
         self._def_value += to_append
         self.assertEqual(self._def, self._def_value)
 
+    def test_is_set(self):
+        raw = self._def_value
+        field = self._ft()
+        self.assertFalse(field.is_set)
+        field.value = raw
+        self.assertTrue(field.is_set)
+
+    def test_reset(self):
+        raw = self._def_value
+        field = self._ft()
+        field.value = raw
+        self.assertTrue(field.is_set)
+        field.reset()
+        self.assertFalse(field.is_set)
+        other = self._ft()
+        self.assertEqual(other, field)
+
 
 class _TestArraySequenceFieldCommon(_TestCopySimple):
     def _modify_def(self):
@@ -1143,6 +1177,24 @@ class _TestArraySequenceFieldCommon(_TestCopySimple):
         values[0]['an_int'] = 'a string'
         with self.assertRaises(TypeError):
             array.value = values
+
+    def test_is_set(self):
+        raw = self._def_value
+        field = self._ft()
+        self.assertFalse(field.is_set)
+        field.value = raw
+        self.assertTrue(field.is_set)
+
+    def test_reset(self):
+        raw = self._def_value
+        field = self._ft()
+        field.value = raw
+        self.assertTrue(field.is_set)
+        field.reset()
+        self.assertFalse(field.is_set)
+        other = self._ft()
+        self.assertEqual(other, field)
+
 
 class ArrayFieldTestCase(_TestArraySequenceFieldCommon, unittest.TestCase):
     def setUp(self):
@@ -1397,6 +1449,48 @@ class StructureFieldTestCase(_TestCopySimple, unittest.TestCase):
             'another_int': 66
         }
 
+    def test_is_set(self):
+        values = {
+            'an_int': 42,
+            'a_string': 'hello',
+            'another_int': 66
+        }
+
+        int_ft = bt2.IntegerFieldType(32)
+        str_ft = bt2.StringFieldType()
+        struct_ft = bt2.StructureFieldType()
+        struct_ft.append_field(field_type=int_ft, name='an_int')
+        struct_ft.append_field(field_type=str_ft, name='a_string')
+        struct_ft.append_field(field_type=int_ft, name='another_int')
+
+        struct = struct_ft()
+        self.assertFalse(struct.is_set)
+        struct.value = values
+        self.assertTrue(struct.is_set)
+
+        struct = struct_ft()
+        struct['an_int'].value = 42
+        self.assertFalse(struct.is_set)
+
+    def test_reset(self):
+        values = {
+            'an_int': 42,
+            'a_string': 'hello',
+            'another_int': 66
+        }
+
+        int_ft = bt2.IntegerFieldType(32)
+        str_ft = bt2.StringFieldType()
+        struct_ft = bt2.StructureFieldType()
+        struct_ft.append_field(field_type=int_ft, name='an_int')
+        struct_ft.append_field(field_type=str_ft, name='a_string')
+        struct_ft.append_field(field_type=int_ft, name='another_int')
+
+        struct = struct_ft()
+        struct.value = values
+        self.assertTrue(struct.is_set)
+        struct.reset()
+        self.assertEqual(struct_ft(), struct)
 
 
 class VariantFieldTestCase(_TestCopySimple, unittest.TestCase):
@@ -1482,3 +1576,17 @@ class VariantFieldTestCase(_TestCopySimple, unittest.TestCase):
 
     def test_eq_invalid_type(self):
         self.assertNotEqual(self._def, 23)
+
+    def test_is_set(self):
+        self.assertFalse(self._def.is_set)
+        tag_field = self._tag_ft(2800)
+        self._def.field(tag_field).value = 684
+        self.assertTrue(self._def.is_set)
+
+    def test_reset(self):
+        tag_field = self._tag_ft(2800)
+        self._def.field(tag_field).value = 684
+        self._def.reset()
+        self.assertFalse(self._def.is_set)
+        self.assertIsNone(self._def.selected_field)
+        self.assertIsNone(self._def.tag_field)

--- a/tests/bindings/python/bt2/test_fields.py
+++ b/tests/bindings/python/bt2/test_fields.py
@@ -34,7 +34,7 @@ class _TestNumericField(_TestCopySimple):
         comp_value = rhs
 
         if isinstance(rhs, (bt2.fields._IntegerField, bt2.fields._FloatingPointNumberField)):
-            comp_value = rhs.value
+            comp_value = copy.copy(rhs)
 
         try:
             r = op(self._def, rhs)
@@ -102,9 +102,9 @@ class _TestNumericField(_TestCopySimple):
         self.assertEqual(self._def.addr, addr_before)
 
     def _test_unaryop_value_same(self, op):
-        value_before = self._def.value
+        value_before = copy.copy(self._def_value)
         self._unaryop(op)
-        self.assertEqual(self._def.value, value_before)
+        self.assertEqual(self._def, value_before)
 
     def _test_binop_type(self, op, rhs):
         r, rv = self._binop(op, rhs)
@@ -132,9 +132,9 @@ class _TestNumericField(_TestCopySimple):
         self.assertEqual(self._def.addr, addr_before)
 
     def _test_binop_lhs_value_same(self, op, rhs):
-        value_before = self._def.value
+        value_before = copy.copy(self._def)
         r, rv = self._binop(op, rhs)
-        self.assertEqual(self._def.value, value_before)
+        self.assertEqual(self._def, value_before)
 
     def _test_binop_invalid_unknown(self, op):
         if op in _COMP_BINOPS:
@@ -717,25 +717,21 @@ class _TestIntegerFieldCommon(_TestNumericField):
         raw = True
         self._def.value = raw
         self.assertEqual(self._def, raw)
-        self.assertEqual(self._def.value, raw)
 
     def test_assign_false(self):
         raw = False
         self._def.value = raw
         self.assertEqual(self._def, raw)
-        self.assertEqual(self._def.value, raw)
 
     def test_assign_pos_int(self):
         raw = 477
         self._def.value = raw
         self.assertEqual(self._def, raw)
-        self.assertEqual(self._def.value, raw)
 
     def test_assign_neg_int(self):
         raw = -13
         self._def.value = raw
         self.assertEqual(self._def, raw)
-        self.assertEqual(self._def.value, raw)
 
     def test_assign_int_field(self):
         raw = 999
@@ -743,13 +739,11 @@ class _TestIntegerFieldCommon(_TestNumericField):
         field.value = raw
         self._def.value = field
         self.assertEqual(self._def, raw)
-        self.assertEqual(self._def.value, raw)
 
     def test_assign_float(self):
         raw = 123.456
         self._def.value = raw
         self.assertEqual(self._def, int(raw))
-        self.assertEqual(self._def.value, int(raw))
 
     def test_assign_invalid_type(self):
         with self.assertRaises(TypeError):
@@ -761,7 +755,6 @@ class _TestIntegerFieldCommon(_TestNumericField):
         raw = 1777
         field.value = 1777
         self.assertEqual(field, raw)
-        self.assertEqual(field.value, raw)
 
     def test_assign_uint_invalid_neg(self):
         ft = bt2.IntegerFieldType(size=32, is_signed=False)
@@ -847,24 +840,20 @@ class FloatingPointNumberFieldTestCase(_TestNumericField, unittest.TestCase):
     def test_assign_true(self):
         self._def.value = True
         self.assertTrue(self._def)
-        self.assertTrue(self._def.value)
 
     def test_assign_false(self):
         self._def.value = False
         self.assertFalse(self._def)
-        self.assertFalse(self._def.value)
 
     def test_assign_pos_int(self):
         raw = 477
         self._def.value = raw
         self.assertEqual(self._def, float(raw))
-        self.assertEqual(self._def.value, float(raw))
 
     def test_assign_neg_int(self):
         raw = -13
         self._def.value = raw
         self.assertEqual(self._def, float(raw))
-        self.assertEqual(self._def.value, float(raw))
 
     def test_assign_int_field(self):
         ft = bt2.IntegerFieldType(32)
@@ -873,13 +862,11 @@ class FloatingPointNumberFieldTestCase(_TestNumericField, unittest.TestCase):
         field.value = raw
         self._def.value = field
         self.assertEqual(self._def, float(raw))
-        self.assertEqual(self._def.value, float(raw))
 
     def test_assign_float(self):
         raw = -19.23
         self._def.value = raw
         self.assertEqual(self._def, raw)
-        self.assertEqual(self._def.value, raw)
 
     def test_assign_float_field(self):
         ft = bt2.FloatingPointNumberFieldType(32)
@@ -888,7 +875,6 @@ class FloatingPointNumberFieldTestCase(_TestNumericField, unittest.TestCase):
         field.value = raw
         self._def.value = field
         self.assertEqual(self._def, raw)
-        self.assertEqual(self._def.value, raw)
 
     def test_assign_invalid_type(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Here are most of the API (C and Python) changes required to allow the implementation of a backward-compatible `babeltrace` python package which shall provide the API that Babeltrace 1.x offered.