### PR TITLE
RFC: Split CTF IR and notification APIs into public and private parts

### DIFF
--- a/include/babeltrace/ctf-ir/event-class-internal.h
+++ b/include/babeltrace/ctf-ir/event-class-internal.h
@@ -61,6 +61,20 @@ struct bt_event_class {
 	GString *emf_uri;
 };
 
+static inline
+struct bt_private_event_class *bt_private_event_class_from_event_class(
+		struct bt_event_class *event_class)
+{
+	return (void *) event_class;
+}
+
+static inline
+struct bt_event_class *bt_event_class_borrow_from_private(
+		struct bt_private_event_class *private_event_class)
+{
+	return (void *) private_event_class;
+}
+
 BT_HIDDEN
 void bt_event_class_freeze(struct bt_event_class *event_class);
 

--- a/include/babeltrace/ctf-ir/event-class.h
+++ b/include/babeltrace/ctf-ir/event-class.h
@@ -112,6 +112,7 @@ considered immutable, except for \link refs reference counting\endlink.
 @sa ctfireventclass
 */
 struct bt_event_class;
+struct bt_private_event_class;
 struct bt_field;
 struct bt_field_type;
 struct bt_stream_class;
@@ -172,6 +173,10 @@ enum bt_event_class_log_level {
 	BT_EVENT_CLASS_LOG_LEVEL_DEBUG		= 14,
 };
 
+// TODO: document
+extern struct bt_event_class *bt_event_class_from_private(
+		struct bt_private_event_class *private_event_class);
+
 /**
 @name Creation and parent access functions
 @{
@@ -202,7 +207,8 @@ Framework URI.
 @prenotnull{name}
 @postsuccessrefcountret1
 */
-extern struct bt_event_class *bt_event_class_create(const char *name);
+extern struct bt_private_event_class *bt_private_event_class_create(
+		const char *name);
 
 /**
 @brief	Returns the parent CTF IR stream class of the CTF IR event
@@ -228,6 +234,11 @@ bt_stream_class_add_event_class().
 */
 extern struct bt_stream_class *bt_event_class_get_stream_class(
 		struct bt_event_class *event_class);
+
+// TODO: document
+extern struct bt_private_stream_class *
+bt_private_event_class_get_private_stream_class(
+		struct bt_private_event_class *private_event_class);
 
 /** @} */
 
@@ -287,8 +298,9 @@ of the stream class to which you eventually add \p event_class.
 @sa bt_event_class_get_id(): Returns the numeric ID of a given
 	event class.
 */
-extern int bt_event_class_set_id(
-		struct bt_event_class *event_class, uint64_t id);
+extern int bt_private_event_class_set_id(
+		struct bt_private_event_class *private_event_class,
+		uint64_t id);
 
 /**
 @brief	Returns the log level of the CTF IR event class \p event_class.
@@ -339,8 +351,8 @@ extern enum bt_event_class_log_level bt_event_class_get_log_level(
 @sa bt_event_class_get_log_level(): Returns the log level of a given
 	event class.
 */
-extern int bt_event_class_set_log_level(
-		struct bt_event_class *event_class,
+extern int bt_private_event_class_set_log_level(
+		struct bt_private_event_class *private_event_class,
 		enum bt_event_class_log_level log_level);
 
 /**
@@ -381,8 +393,8 @@ extern const char *bt_event_class_get_emf_uri(
 @sa bt_event_class_get_emf_uri(): Returns the Eclipse Modeling
 	Framework URI of a given event class.
 */
-extern int bt_event_class_set_emf_uri(
-		struct bt_event_class *event_class,
+extern int bt_private_event_class_set_emf_uri(
+		struct bt_private_event_class *private_event_class,
 		const char *emf_uri);
 
 /** @} */
@@ -440,8 +452,8 @@ As of Babeltrace \btversion, if \p context_type is not \c NULL,
 @sa bt_event_class_get_context_type(): Returns the context field type of a
 	given event class.
 */
-extern int bt_event_class_set_context_type(
-		struct bt_event_class *event_class,
+extern int bt_private_event_class_set_context_type(
+		struct bt_private_event_class *private_event_class,
 		struct bt_field_type *context_type);
 
 /**
@@ -492,8 +504,8 @@ As of Babeltrace \btversion, if \p payload_type is not \c NULL,
 @sa bt_event_class_get_payload_type(): Returns the payload field type of a
 	given event class.
 */
-extern int bt_event_class_set_payload_type(
-		struct bt_event_class *event_class,
+extern int bt_private_event_class_set_payload_type(
+		struct bt_private_event_class *private_event_class,
 		struct bt_field_type *payload_type);
 
 /**
@@ -610,7 +622,8 @@ adding a field to it with bt_field_type_structure_add_field().
 @postrefcountsame{event_class}
 @postsuccessrefcountinc{field_type}
 */
-extern int bt_event_class_add_field(struct bt_event_class *event_class,
+extern int bt_private_event_class_add_field(
+		struct bt_private_event_class *private_event_class,
 		struct bt_field_type *field_type,
 		const char *name);
 
@@ -619,10 +632,12 @@ extern int bt_event_class_add_field(struct bt_event_class *event_class,
 /** @} */
 
 /* Pre-2.0 CTF writer compatibility */
-#define bt_ctf_event_class bt_event_class
-#define bt_ctf_event_class_create bt_event_class_create
-#define bt_ctf_event_class_get_field_by_name bt_event_class_get_payload_type_field_type_by_name
-#define bt_ctf_event_class_add_field bt_event_class_add_field
+#define bt_ctf_event_class bt_private_event_class
+#define bt_ctf_event_class_create bt_private_event_class_create
+#define bt_ctf_event_class_add_field bt_private_event_class_add_field
+
+extern struct bt_ctf_field_type *bt_ctf_event_class_get_field_by_name(
+		struct bt_ctf_event_class *event_class, const char *name);
 
 #ifdef __cplusplus
 }

--- a/include/babeltrace/ctf-ir/event-internal.h
+++ b/include/babeltrace/ctf-ir/event-internal.h
@@ -53,6 +53,19 @@ struct bt_event {
 	int frozen;
 };
 
+static inline
+struct bt_private_event *bt_private_event_from_event(struct bt_event *event)
+{
+	return (void *) event;
+}
+
+static inline
+struct bt_event *bt_event_borrow_from_private(
+		struct bt_private_event *private_event)
+{
+	return (void *) private_event;
+}
+
 BT_HIDDEN
 int bt_event_validate(struct bt_event *event);
 

--- a/include/babeltrace/ctf-ir/event.h
+++ b/include/babeltrace/ctf-ir/event.h
@@ -118,13 +118,21 @@ immutable, except for \link refs reference counting\endlink.
 @sa ctfirevent
 */
 struct bt_event;
+struct bt_private_event;
 struct bt_clock;
 struct bt_clock_value;
+struct bt_private_event_class;
 struct bt_event_class;
 struct bt_field;
 struct bt_field_type;
+struct bt_private_stream_class;
 struct bt_stream_class;
+struct bt_private_packet;
 struct bt_packet;
+
+// TODO: document
+extern struct bt_event *bt_event_from_private(
+		struct bt_private_event *private_event);
 
 /**
 @name Creation and parent access functions
@@ -162,8 +170,8 @@ with bt_trace_add_stream_class(), then this function fails.
 @pre \p event_class has a parent stream class.
 @postsuccessrefcountret1
 */
-extern struct bt_event *bt_event_create(
-		struct bt_event_class *event_class);
+extern struct bt_private_event *bt_private_event_create(
+		struct bt_private_event_class *private_event_class);
 
 /**
 @brief	Returns the parent CTF IR event class of the CTF IR event
@@ -182,6 +190,10 @@ create the event object in the first place with bt_event_create().
 */
 extern struct bt_event_class *bt_event_get_class(
 		struct bt_event *event);
+
+// TODO: document
+extern struct bt_private_event_class *bt_private_event_get_private_class(
+		struct bt_private_event *event);
 
 /**
 @brief	Returns the CTF IR packet associated to the CTF IR event
@@ -235,8 +247,8 @@ On success, this function also sets the parent stream object of
 @sa bt_event_get_packet(): Returns the associated packet of a
 	given event object.
 */
-extern int bt_event_set_packet(struct bt_event *event,
-		struct bt_packet *packet);
+extern int bt_private_event_set_private_packet(struct bt_private_event *event,
+		struct bt_private_packet *private_packet);
 
 /**
 @brief	Returns the parent CTF IR stream associated to the CTF IR event
@@ -251,6 +263,10 @@ extern int bt_event_set_packet(struct bt_event *event,
 */
 extern struct bt_stream *bt_event_get_stream(
 		struct bt_event *event);
+
+// TODO: document
+extern struct bt_private_stream *bt_private_event_get_private_stream(
+		struct bt_private_event *private_event);
 
 /** @} */
 
@@ -306,7 +322,7 @@ of \p event.
 @sa bt_event_get_header(): Returns the stream event header field
 	of a given event.
 */
-extern int bt_event_set_header(struct bt_event *event,
+extern int bt_private_event_set_header(struct bt_private_event *private_event,
 		struct bt_field *header);
 
 /**
@@ -355,7 +371,8 @@ of \p event.
 @sa bt_event_get_stream_event_context(): Returns the stream event context
 	field of a given event.
 */
-extern int bt_event_set_stream_event_context(struct bt_event *event,
+extern int bt_private_event_set_stream_event_context(
+		struct bt_private_event *private_event,
 		struct bt_field *context);
 
 /**
@@ -398,7 +415,8 @@ bt_event_class_get_context_type() for the parent class of \p event.
 
 @sa bt_event_get_context(): Returns the context field of a given event.
 */
-extern int bt_event_set_event_context(struct bt_event *event,
+extern int bt_private_event_set_event_context(
+		struct bt_private_event *private_event,
 		struct bt_field *context);
 
 /**
@@ -441,7 +459,8 @@ bt_event_class_get_payload_type() for the parent class of \p event.
 
 @sa bt_event_get_payload(): Returns the payload field of a given event.
 */
-extern int bt_event_set_event_payload(struct bt_event *event,
+extern int bt_private_event_set_event_payload(
+		struct bt_private_event *private_event,
 		struct bt_field *payload);
 
 /** @cond DOCUMENT */
@@ -504,9 +523,8 @@ extern struct bt_field *bt_event_get_payload_by_index(
  *	type is not a structure. If name is NULL, the payload field will be set
  *	directly and must match the event class' payload's type.
  */
-extern int bt_event_set_payload(struct bt_event *event,
-		const char *name,
-		struct bt_field *value);
+extern int bt_private_event_set_payload(struct bt_private_event *private_event,
+		const char *name, struct bt_field *value);
 
 /** @endcond */
 
@@ -559,8 +577,8 @@ extern struct bt_clock_value *bt_event_get_clock_value(
 @sa bt_event_get_clock_value(): Returns the clock value of
 	a given event.
 */
-extern int bt_event_set_clock_value(
-		struct bt_event *event,
+extern int bt_private_event_set_clock_value(
+		struct bt_private_event *private_event,
 		struct bt_clock_value *clock_value);
 
 /** @} */
@@ -568,10 +586,12 @@ extern int bt_event_set_clock_value(
 /** @} */
 
 /* Pre-2.0 CTF writer compatibility */
-#define bt_ctf_event bt_event
-#define bt_ctf_event_create bt_event_create
-#define bt_ctf_event_get_payload bt_event_get_payload
-#define bt_ctf_event_set_payload bt_event_set_payload
+#define bt_ctf_event bt_private_event
+#define bt_ctf_event_create bt_private_event_create
+#define bt_ctf_event_set_payload bt_private_event_set_payload
+
+extern struct bt_ctf_field *bt_ctf_event_get_payload(struct bt_ctf_event *event,
+		const char *name);
 
 #ifdef __cplusplus
 }

--- a/include/babeltrace/ctf-ir/packet-internal.h
+++ b/include/babeltrace/ctf-ir/packet-internal.h
@@ -39,6 +39,20 @@ struct bt_packet {
 	int frozen;
 };
 
+static inline
+struct bt_private_packet *bt_private_packet_from_packet(
+		struct bt_packet *packet)
+{
+	return (void *) packet;
+}
+
+static inline
+struct bt_packet *bt_packet_borrow_from_private(
+		struct bt_private_packet *private_packet)
+{
+	return (void *) private_packet;
+}
+
 BT_HIDDEN
 void bt_packet_freeze(struct bt_packet *packet);
 

--- a/include/babeltrace/ctf-ir/packet.h
+++ b/include/babeltrace/ctf-ir/packet.h
@@ -94,7 +94,13 @@ except for \link refs reference counting\endlink.
 @sa ctfirpacket
 */
 struct bt_packet;
+struct bt_private_packet;
 struct bt_stream;
+struct bt_private_stream;
+
+// TODO: document
+extern struct bt_packet *bt_packet_from_private(
+		struct bt_private_packet *private_packet);
 
 /**
 @name Creation and parent access functions
@@ -115,8 +121,8 @@ bt_packet_set_header() and bt_packet_set_context().
 @prenotnull{stream}
 @postsuccessrefcountret1
 */
-extern struct bt_packet *bt_packet_create(
-		struct bt_stream *stream);
+extern struct bt_private_packet *bt_private_packet_create(
+		struct bt_private_stream *private_stream);
 
 /**
 @brief	Returns the parent CTF IR stream of the CTF IR packet \p packet.
@@ -131,8 +137,11 @@ the packet object in the first place with bt_packet_create().
 @postrefcountsame{packet}
 @postsuccessrefcountretinc
 */
-extern struct bt_stream *bt_packet_get_stream(
-		struct bt_packet *packet);
+extern struct bt_stream *bt_packet_get_stream(struct bt_packet *packet);
+
+// TODO: document
+extern struct bt_private_stream *bt_private_packet_get_private_stream(
+		struct bt_private_packet *packet);
 
 /** @} */
 
@@ -187,8 +196,9 @@ bt_trace_get_packet_header_type() for the parent trace class of
 @sa bt_packet_get_header(): Returns the trace packet header field of a given
 	packet.
 */
-extern int bt_packet_set_header(
-		struct bt_packet *packet, struct bt_field *header);
+extern int bt_private_packet_set_header(
+		struct bt_private_packet *private_packet,
+		struct bt_field *header);
 
 /**
 @brief	Returns the stream packet context field of the CTF IR packet
@@ -235,8 +245,9 @@ bt_stream_class_get_packet_context_type() for the parent stream class of
 @sa bt_packet_get_context(): Returns the stream packet context field of a
 	given packet.
 */
-extern int bt_packet_set_context(
-		struct bt_packet *packet, struct bt_field *context);
+extern int bt_private_packet_set_context(
+		struct bt_private_packet *private_packet,
+		struct bt_field *context);
 
 /** @} */
 

--- a/include/babeltrace/ctf-ir/stream-class-internal.h
+++ b/include/babeltrace/ctf-ir/stream-class-internal.h
@@ -61,6 +61,20 @@ struct bt_stream_class {
 	int valid;
 };
 
+static inline
+struct bt_private_stream_class *bt_private_stream_class_from_stream_class(
+		struct bt_stream_class *stream_class)
+{
+	return (void *) stream_class;
+}
+
+static inline
+struct bt_stream_class *bt_stream_class_borrow_from_private(
+		struct bt_private_stream_class *private_stream_class)
+{
+	return (void *) private_stream_class;
+}
+
 BT_HIDDEN
 void bt_stream_class_freeze(struct bt_stream_class *stream_class);
 

--- a/include/babeltrace/ctf-ir/stream-class.h
+++ b/include/babeltrace/ctf-ir/stream-class.h
@@ -136,6 +136,7 @@ except for:
 @brief A CTF IR stream class.
 @sa ctfirstreamclass
 */
+struct bt_private_stream_class;
 struct bt_stream_class;
 struct bt_event_class;
 struct bt_clock;
@@ -144,6 +145,10 @@ struct bt_clock;
 @name Creation and parent access functions
 @{
 */
+
+// TODO: document
+extern struct bt_stream_class *bt_stream_class_from_private(
+		struct bt_private_stream_class *private_stream_class);
 
 /**
 @brief	Creates an empty CTF IR stream class named \p name, or an
@@ -164,7 +169,7 @@ bt_stream_class_set_event_context_type().
 
 @sa bt_stream_class_create(): Creates a default stream class.
 */
-extern struct bt_stream_class *bt_stream_class_create_empty(
+extern struct bt_private_stream_class *bt_private_stream_class_create_empty(
 		const char *name);
 
 /**
@@ -198,7 +203,8 @@ bt_stream_class_set_event_header_type().
 
 @sa bt_stream_class_create_empty(): Creates an empty stream class.
 */
-extern struct bt_stream_class *bt_stream_class_create(const char *name);
+extern struct bt_private_stream_class *bt_private_stream_class_create(
+		const char *name);
 
 /**
 @brief	Returns the parent CTF IR trace class of the CTF IR stream
@@ -224,6 +230,10 @@ bt_trace_add_stream_class().
 */
 extern struct bt_trace *bt_stream_class_get_trace(
 		struct bt_stream_class *stream_class);
+
+// TODO: document
+extern struct bt_private_trace *bt_private_stream_class_get_private_trace(
+		struct bt_private_stream_class *private_stream_class);
 
 /** @} */
 
@@ -274,8 +284,9 @@ the stream classes of the trace class to which you eventually add
 @sa bt_stream_class_get_name(): Returns the name of a given
 	stream class.
 */
-extern int bt_stream_class_set_name(
-		struct bt_stream_class *stream_class, const char *name);
+extern int bt_private_stream_class_set_name(
+		struct bt_private_stream_class *private_stream_class,
+		const char *name);
 
 /**
 @brief	Returns the numeric ID of the CTF IR stream class \p stream_class.
@@ -312,8 +323,9 @@ of the trace class to which you eventually add \p stream_class.
 @sa bt_stream_class_get_id(): Returns the numeric ID of a given
 	stream class.
 */
-extern int bt_stream_class_set_id(
-		struct bt_stream_class *stream_class, uint64_t id);
+extern int bt_private_stream_class_set_id(
+		struct bt_private_stream_class *private_stream_class,
+		uint64_t id);
 
 /** @} */
 
@@ -372,8 +384,8 @@ As of Babeltrace \btversion, if \p packet_context_type is not \c NULL,
 @sa bt_stream_class_get_packet_context_type(): Returns the packet
 	context field type of a given stream class.
 */
-extern int bt_stream_class_set_packet_context_type(
-		struct bt_stream_class *stream_class,
+extern int bt_private_stream_class_set_packet_context_type(
+		struct bt_private_stream_class *private_stream_class,
 		struct bt_field_type *packet_context_type);
 
 /**
@@ -394,8 +406,7 @@ extern int bt_stream_class_set_packet_context_type(
 @sa bt_stream_class_set_event_header_type(): Sets the event
 	header field type of a given stream class.
 */
-extern struct bt_field_type *
-bt_stream_class_get_event_header_type(
+extern struct bt_field_type *bt_stream_class_get_event_header_type(
 		struct bt_stream_class *stream_class);
 
 /**
@@ -427,8 +438,8 @@ As of Babeltrace \btversion, if \p event_header_type is not \c NULL,
 @sa bt_stream_class_get_event_header_type(): Returns the event
 	header field type of a given stream class.
 */
-extern int bt_stream_class_set_event_header_type(
-		struct bt_stream_class *stream_class,
+extern int bt_private_stream_class_set_event_header_type(
+		struct bt_private_stream_class *private_stream_class,
 		struct bt_field_type *event_header_type);
 
 /**
@@ -483,8 +494,8 @@ As of Babeltrace \btversion, if \p event_context_type is not \c NULL,
 @sa bt_stream_class_get_event_context_type(): Returns the event context
 	field type of a given stream class.
 */
-extern int bt_stream_class_set_event_context_type(
-		struct bt_stream_class *stream_class,
+extern int bt_private_stream_class_set_event_context_type(
+		struct bt_private_stream_class *private_stream_class,
 		struct bt_field_type *event_context_type);
 
 /** @} */
@@ -532,6 +543,12 @@ extern int64_t bt_stream_class_get_event_class_count(
 extern struct bt_event_class *bt_stream_class_get_event_class_by_index(
 		struct bt_stream_class *stream_class, uint64_t index);
 
+// TODO: document
+extern struct bt_private_event_class *
+bt_private_stream_class_get_private_event_class_by_index(
+		struct bt_private_stream_class *private_stream_class,
+		uint64_t index);
+
 /**
 @brief  Returns the event class with ID \c id found in the CTF IR stream
 	class \p stream_class.
@@ -547,6 +564,12 @@ extern struct bt_event_class *bt_stream_class_get_event_class_by_index(
 */
 extern struct bt_event_class *bt_stream_class_get_event_class_by_id(
 		struct bt_stream_class *stream_class, uint64_t id);
+
+// TODO: document
+extern struct bt_private_event_class *
+bt_private_stream_class_get_private_event_class_by_id(
+		struct bt_private_stream_class *private_stream_class,
+		uint64_t id);
 
 /**
 @brief	Adds the CTF IR event class \p event_class to the
@@ -585,9 +608,9 @@ types of \p event_class. If any automatic resolving fails:
 @postsuccessrefcountinc{event_class}
 @postsuccessfrozen{event_class}
 */
-extern int bt_stream_class_add_event_class(
-		struct bt_stream_class *stream_class,
-		struct bt_event_class *event_class);
+extern int bt_private_stream_class_add_private_event_class(
+		struct bt_private_stream_class *private_stream_class,
+		struct bt_private_event_class *private_event_class);
 
 /** @} */
 
@@ -622,10 +645,12 @@ extern int bt_stream_class_visit(struct bt_stream_class *stream_class,
 /** @} */
 
 /* Pre-2.0 CTF writer compatibility */
-#define bt_ctf_stream_class bt_stream_class
-#define bt_ctf_stream_class_create bt_stream_class_create
-#define bt_ctf_stream_class_add_event_class bt_stream_class_add_event_class
-#define bt_ctf_stream_class_get_packet_context_type bt_stream_class_get_packet_context_type
+#define bt_ctf_stream_class bt_private_stream_class
+#define bt_ctf_stream_class_create bt_private_stream_class_create
+#define bt_ctf_stream_class_add_event_class bt_private_stream_class_add_private_event_class
+
+extern struct bt_ctf_field_type *bt_ctf_stream_class_get_packet_context_type(
+		struct bt_ctf_stream_class *stream_class);
 
 #ifdef __cplusplus
 }

--- a/include/babeltrace/ctf-ir/stream-internal.h
+++ b/include/babeltrace/ctf-ir/stream-internal.h
@@ -87,6 +87,20 @@ struct bt_stream {
 	GArray *destroy_listeners;
 };
 
+static inline
+struct bt_private_stream *bt_private_stream_from_stream(
+		struct bt_stream *stream)
+{
+	return (void *) stream;
+}
+
+static inline
+struct bt_stream *bt_stream_borrow_from_private(
+		struct bt_private_stream *private_stream)
+{
+	return (void *) private_stream;
+}
+
 BT_HIDDEN
 int bt_stream_set_fd(struct bt_stream *stream, int fd);
 

--- a/include/babeltrace/ctf-ir/stream.h
+++ b/include/babeltrace/ctf-ir/stream.h
@@ -37,6 +37,7 @@ extern "C" {
 #endif
 
 struct bt_stream_class;
+struct bt_private_stream_class;
 
 /**
 @defgroup ctfirstream CTF IR stream
@@ -97,8 +98,13 @@ management of Babeltrace objects.
 @sa ctfirstream
 @sa ctfwriterstream
 */
+struct bt_private_stream;
 struct bt_stream;
 struct bt_event;
+
+// TODO: document
+extern struct bt_stream *bt_stream_from_private(
+		struct bt_private_stream *private_stream);
 
 /**
 @brief  Creates a default CTF IR stream named \p name from the CTF IR
@@ -129,8 +135,8 @@ functions documented in this module on it.
 @sa bt_stream_create_with_id(): Create a CTF IR stream with a
 	specific ID.
 */
-extern struct bt_stream *bt_stream_create(
-		struct bt_stream_class *stream_class,
+extern struct bt_private_stream *bt_private_stream_create(
+		struct bt_private_stream_class *private_stream_class,
 		const char *name);
 
 /**
@@ -163,8 +169,8 @@ from \p stream_class with bt_stream_create_with_id().
 
 @sa bt_stream_create(): Create a CTF IR stream without an ID.
 */
-extern struct bt_stream *bt_stream_create_with_id(
-		struct bt_stream_class *stream_class,
+extern struct bt_private_stream *bt_private_stream_create_with_id(
+		struct bt_private_stream_class *private_stream_class,
 		const char *name, uint64_t id);
 
 /**
@@ -212,10 +218,14 @@ bt_stream_create().
 extern struct bt_stream_class *bt_stream_get_class(
 		struct bt_stream *stream);
 
+// TODO: document
+extern struct bt_private_stream_class *bt_private_stream_get_private_class(
+		struct bt_private_stream *private_stream);
+
 /** @} */
 
 /* Pre-2.0 CTF writer compatibility */
-#define bt_ctf_stream bt_stream
+#define bt_ctf_stream bt_private_stream
 
 #ifdef __cplusplus
 }

--- a/include/babeltrace/ctf-ir/trace-internal.h
+++ b/include/babeltrace/ctf-ir/trace-internal.h
@@ -80,6 +80,19 @@ struct metadata_context {
 	unsigned int current_indentation_level;
 };
 
+static inline
+struct bt_private_trace *bt_private_trace_from_trace(struct bt_trace *trace)
+{
+	return (void *) trace;
+}
+
+static inline
+struct bt_trace *bt_trace_borrow_from_private(
+		struct bt_private_trace *private_trace)
+{
+	return (void *) private_trace;
+}
+
 BT_HIDDEN
 const char *get_byte_order_string(int byte_order);
 

--- a/include/babeltrace/ctf-ir/trace.h
+++ b/include/babeltrace/ctf-ir/trace.h
@@ -145,6 +145,7 @@ except for:
 @brief A CTF IR trace class.
 @sa ctfirtraceclass
 */
+struct bt_private_trace;
 struct bt_trace;
 struct bt_stream;
 struct bt_stream_class;
@@ -183,6 +184,10 @@ typedef void (* bt_trace_listener_removed)(
 @{
 */
 
+// TODO: document
+extern struct bt_trace *bt_trace_from_private(
+		struct bt_private_trace *private_trace);
+
 /**
 @brief	Creates a default CTF IR trace class.
 
@@ -210,7 +215,7 @@ The created trace class has the following initial properties:
 
 @postsuccessrefcountret1
 */
-extern struct bt_trace *bt_trace_create(void);
+extern struct bt_private_trace *bt_private_trace_create(void);
 
 /** @} */
 
@@ -253,7 +258,7 @@ extern const char *bt_trace_get_name(struct bt_trace *trace_class);
 
 @sa bt_trace_get_name(): Returns the name of a given trace class.
 */
-extern int bt_trace_set_name(struct bt_trace *trace_class,
+extern int bt_private_trace_set_name(struct bt_private_trace *private_trace,
 		const char *name);
 
 /**
@@ -302,7 +307,8 @@ extern enum bt_byte_order bt_trace_get_native_byte_order(
 @sa bt_trace_get_native_byte_order(): Returns the native byte order of a
 	given trace class.
 */
-extern int bt_trace_set_native_byte_order(struct bt_trace *trace_class,
+extern int bt_private_trace_set_native_byte_order(
+		struct bt_private_trace *private_trace,
 		enum bt_byte_order native_byte_order);
 
 /**
@@ -341,7 +347,7 @@ extern const unsigned char *bt_trace_get_uuid(
 
 @sa bt_trace_get_uuid(): Returns the UUID of a given trace class.
 */
-extern int bt_trace_set_uuid(struct bt_trace *trace_class,
+extern int bt_private_trace_set_uuid(struct bt_private_trace *private_trace,
 		const unsigned char *uuid);
 
 /**
@@ -470,8 +476,8 @@ value is first put, and then replaced by \p value.
 @sa bt_trace_get_environment_field_value_by_name(): Finds a trace
 	class's environment entry by name.
 */
-extern int bt_trace_set_environment_field(
-		struct bt_trace *trace_class, const char *name,
+extern int bt_private_trace_set_environment_field(
+		struct bt_private_trace *private_trace, const char *name,
 		struct bt_value *value);
 
 /**
@@ -498,8 +504,8 @@ containing \p value.
 @sa bt_trace_set_environment_field(): Sets the value of a trace
 	class's environment entry.
 */
-extern int bt_trace_set_environment_field_integer(
-		struct bt_trace *trace_class, const char *name,
+extern int bt_private_trace_set_environment_field_integer(
+		struct bt_private_trace *private_trace, const char *name,
 		int64_t value);
 
 /**
@@ -528,8 +534,8 @@ containing \p value.
 @sa bt_trace_set_environment_field(): Sets the value of a trace
 	class's environment entry.
 */
-extern int bt_trace_set_environment_field_string(
-		struct bt_trace *trace_class, const char *name,
+extern int bt_private_trace_set_environment_field_string(
+		struct bt_private_trace *private_trace, const char *name,
 		const char *value);
 
 /** @} */
@@ -589,7 +595,8 @@ As of Babeltrace \btversion, if \p packet_header_type is not \c NULL,
 @sa bt_trace_get_packet_header_type(): Returns the packet
 	header field type of a given trace class.
 */
-extern int bt_trace_set_packet_header_type(struct bt_trace *trace_class,
+extern int bt_private_trace_set_packet_header_type(
+		struct bt_private_trace *private_trace,
 		struct bt_field_type *packet_header_type);
 
 /** @} */
@@ -687,7 +694,8 @@ are frozen.
 @sa bt_trace_get_clock_class_by_name(): Finds a clock class by name
 	in a given trace class.
 */
-extern int bt_trace_add_clock_class(struct bt_trace *trace_class,
+extern int bt_private_trace_add_clock_class(
+		struct bt_private_trace *private_trace,
 		struct bt_clock_class *clock_class);
 
 /** @} */
@@ -734,6 +742,11 @@ extern int64_t bt_trace_get_stream_class_count(
 extern struct bt_stream_class *bt_trace_get_stream_class_by_index(
 		struct bt_trace *trace_class, uint64_t index);
 
+// TODO: document
+extern struct bt_private_stream_class *
+bt_private_trace_get_private_stream_class_by_index(
+		struct bt_private_trace *private_trace, uint64_t index);
+
 /**
 @brief  Returns the stream class with ID \c id found in the CTF IR
 	trace class \p trace_class.
@@ -753,6 +766,11 @@ extern struct bt_stream_class *bt_trace_get_stream_class_by_index(
 */
 extern struct bt_stream_class *bt_trace_get_stream_class_by_id(
 		struct bt_trace *trace_class, uint64_t id);
+
+// TODO: document
+extern struct bt_private_stream_class *
+bt_private_trace_get_private_stream_class_by_id(
+		struct bt_private_trace *private_trace, uint64_t id);
 
 /**
 @brief	Adds the CTF IR stream class \p stream_class to the
@@ -785,8 +803,9 @@ resolving fails, then this function fails.
 	in a given trace class at a given index.
 @sa bt_trace_get_stream_class_by_id(): Finds a stream class by ID.
 */
-extern int bt_trace_add_stream_class(struct bt_trace *trace_class,
-		struct bt_stream_class *stream_class);
+extern int bt_private_trace_add_private_stream_class(
+		struct bt_private_trace *private_trace,
+		struct bt_private_stream_class *private_stream_class);
 
 /** @} */
 
@@ -827,6 +846,10 @@ extern int64_t bt_trace_get_stream_count(struct bt_trace *trace_class);
 */
 extern struct bt_stream *bt_trace_get_stream_by_index(
 		struct bt_trace *trace_class, uint64_t index);
+
+// TODO: document
+extern struct bt_private_stream *bt_private_trace_get_private_stream_by_index(
+		struct bt_private_trace *private_trace, uint64_t index);
 
 /** @} */
 
@@ -881,7 +904,8 @@ stream classes of a static trace class.
 @sa bt_trace_add_is_static_listener(): Adds a listener to a trace
 	class which is called when the trace class is made static.
 */
-extern int bt_trace_set_is_static(struct bt_trace *trace_class);
+extern int bt_private_trace_set_is_static(
+		struct bt_private_trace *private_trace);
 
 /**
 @brief  Adds the listener \p listener to the CTF IR trace class
@@ -984,7 +1008,7 @@ extern int bt_trace_visit(struct bt_trace *trace_class,
 /** @} */
 
 /* Pre-2.0 CTF writer compatibility */
-#define bt_ctf_trace bt_trace
+#define bt_ctf_trace bt_private_trace
 
 #ifdef __cplusplus
 }

--- a/include/babeltrace/ctf-writer/stream-class.h
+++ b/include/babeltrace/ctf-writer/stream-class.h
@@ -47,15 +47,15 @@ extern "C" {
  *
  * Returns 0 on success, a negative value on error.
  */
-extern int bt_stream_class_set_clock(
-		struct bt_stream_class *stream_class,
+extern int bt_private_stream_class_set_clock(
+		struct bt_private_stream_class *private_stream_class,
 		struct bt_ctf_clock *clock);
 
-extern struct bt_ctf_clock *bt_stream_class_get_clock(
-        struct bt_stream_class *stream_class);
+extern struct bt_ctf_clock *bt_private_stream_class_get_clock(
+        struct bt_private_stream_class *private_stream_class);
 
 /* Pre-2.0 CTF writer compatibility */
-#define bt_ctf_stream_class_set_clock bt_stream_class_set_clock
+#define bt_ctf_stream_class_set_clock bt_private_stream_class_set_clock
 
 extern void bt_ctf_stream_class_get(struct bt_ctf_stream_class *stream_class);
 extern void bt_ctf_stream_class_put(struct bt_ctf_stream_class *stream_class);

--- a/include/babeltrace/ctf-writer/stream.h
+++ b/include/babeltrace/ctf-writer/stream.h
@@ -50,8 +50,8 @@ extern "C" {
  *
  * Returns the number of discarded events, a negative value on error.
  */
-extern int bt_stream_get_discarded_events_count(
-		struct bt_stream *stream, uint64_t *count);
+extern int bt_private_stream_get_discarded_events_count(
+		struct bt_private_stream *stream, uint64_t *count);
 
 /*
  * bt_stream_append_discarded_events: increment discarded events count.
@@ -63,7 +63,8 @@ extern int bt_stream_get_discarded_events_count(
  * @param event_count Number of discarded events to add to the stream's current
  *	packet.
  */
-extern void bt_stream_append_discarded_events(struct bt_stream *stream,
+extern void bt_private_stream_append_discarded_events(
+		struct bt_private_stream *stream,
 		uint64_t event_count);
 
 /*
@@ -83,8 +84,9 @@ extern void bt_stream_append_discarded_events(struct bt_stream *stream,
  *
  * Returns 0 on success, a negative value on error.
  */
-extern int bt_stream_append_event(struct bt_stream *stream,
-		struct bt_event *event);
+extern int bt_private_stream_append_private_event(
+		struct bt_private_stream *stream,
+		struct bt_private_event *event);
 
 /*
  * bt_stream_get_packet_header: get a stream's packet header.
@@ -93,8 +95,8 @@ extern int bt_stream_append_event(struct bt_stream *stream,
  *
  * Returns a field instance on success, NULL on error.
  */
-extern struct bt_field *bt_stream_get_packet_header(
-		struct bt_stream *stream);
+extern struct bt_field *bt_private_stream_get_packet_header(
+		struct bt_private_stream *stream);
 
 /*
  * bt_stream_set_packet_header: set a stream's packet header.
@@ -107,8 +109,8 @@ extern struct bt_field *bt_stream_get_packet_header(
  *
  * Returns a field instance on success, NULL on error.
  */
-extern int bt_stream_set_packet_header(
-		struct bt_stream *stream,
+extern int bt_private_stream_set_packet_header(
+		struct bt_private_stream *stream,
 		struct bt_field *packet_header);
 
 /*
@@ -118,8 +120,8 @@ extern int bt_stream_set_packet_header(
  *
  * Returns a field instance on success, NULL on error.
  */
-extern struct bt_field *bt_stream_get_packet_context(
-		struct bt_stream *stream);
+extern struct bt_field *bt_private_stream_get_packet_context(
+		struct bt_private_stream *stream);
 
 /*
  * bt_stream_set_packet_context: set a stream's packet context.
@@ -132,8 +134,8 @@ extern struct bt_field *bt_stream_get_packet_context(
  *
  * Returns a field instance on success, NULL on error.
  */
-extern int bt_stream_set_packet_context(
-		struct bt_stream *stream,
+extern int bt_private_stream_set_packet_context(
+		struct bt_private_stream *stream,
 		struct bt_field *packet_context);
 
 /*
@@ -151,19 +153,19 @@ extern int bt_stream_set_packet_context(
  *
  * Returns 0 on success, a negative value on error.
  */
-extern int bt_stream_flush(struct bt_stream *stream);
+extern int bt_private_stream_flush(struct bt_private_stream *stream);
 
 extern int bt_stream_is_writer(struct bt_stream *stream);
 
 /* Pre-2.0 CTF writer compatibility */
-#define bt_ctf_stream_get_discarded_events_count bt_stream_get_discarded_events_count
-#define bt_ctf_stream_append_discarded_events bt_stream_append_discarded_events
-#define bt_ctf_stream_append_event bt_stream_append_event
-#define bt_ctf_stream_get_packet_context bt_stream_get_packet_context
-#define bt_ctf_stream_flush bt_stream_flush
+#define bt_ctf_stream_get_discarded_events_count bt_private_stream_get_discarded_events_count
+#define bt_ctf_stream_append_discarded_events bt_private_stream_append_discarded_events
+#define bt_ctf_stream_append_event bt_private_stream_append_private_event
+#define bt_ctf_stream_get_packet_context bt_private_stream_get_packet_context
+#define bt_ctf_stream_flush bt_private_stream_flush
 
-extern void bt_ctf_stream_get(struct bt_stream *stream);
-extern void bt_ctf_stream_put(struct bt_stream *stream);
+extern void bt_ctf_stream_get(struct bt_private_stream *stream);
+extern void bt_ctf_stream_put(struct bt_private_stream *stream);
 
 #ifdef __cplusplus
 }

--- a/include/babeltrace/graph/notification-event.h
+++ b/include/babeltrace/graph/notification-event.h
@@ -31,7 +31,9 @@
 extern "C" {
 #endif
 
+struct bt_private_notification;
 struct bt_notification;
+struct bt_private_event;
 struct bt_event;
 struct bt_clock_class_priority_map;
 
@@ -44,8 +46,8 @@ struct bt_clock_class_priority_map;
  *
  * @see #bt_notification_type
  */
-extern struct bt_notification *bt_notification_event_create(
-		struct bt_event *event,
+extern struct bt_private_notification *bt_private_notification_event_create(
+		struct bt_private_event *private_event,
 		struct bt_clock_class_priority_map *clock_class_priority_map);
 
 /**

--- a/include/babeltrace/graph/notification-inactivity.h
+++ b/include/babeltrace/graph/notification-inactivity.h
@@ -31,7 +31,7 @@ struct bt_notification;
 struct bt_clock_class_priority_map;
 struct bt_clock_class;
 
-extern struct bt_notification *bt_notification_inactivity_create(
+extern struct bt_private_notification *bt_private_notification_inactivity_create(
 		struct bt_clock_class_priority_map *clock_class_priority_map);
 
 extern struct bt_clock_class_priority_map *
@@ -42,8 +42,8 @@ extern struct bt_clock_value *bt_notification_inactivity_get_clock_value(
 		struct bt_notification *notification,
 		struct bt_clock_class *clock_class);
 
-extern int bt_notification_inactivity_set_clock_value(
-		struct bt_notification *notification,
+extern int bt_private_notification_inactivity_set_clock_value(
+		struct bt_private_notification *private_notification,
 		struct bt_clock_value *clock_value);
 
 #ifdef __cplusplus

--- a/include/babeltrace/graph/notification-internal.h
+++ b/include/babeltrace/graph/notification-internal.h
@@ -44,6 +44,13 @@ struct bt_notification {
 	bt_bool frozen;
 };
 
+static inline
+struct bt_private_notification *bt_private_notification_from_notification(
+		struct bt_notification *notification)
+{
+	return (void *) notification;
+}
+
 BT_HIDDEN
 void bt_notification_init(struct bt_notification *notification,
 		enum bt_notification_type type,

--- a/include/babeltrace/graph/notification-packet.h
+++ b/include/babeltrace/graph/notification-packet.h
@@ -31,14 +31,18 @@
 extern "C" {
 #endif
 
+struct bt_private_notification;
 struct bt_notification;
+struct bt_private_packet;
 struct bt_packet;
 
-extern struct bt_notification *bt_notification_packet_begin_create(
-		struct bt_packet *packet);
+extern struct bt_private_notification *
+bt_private_notification_packet_begin_create(
+		struct bt_private_packet *private_packet);
 
-extern struct bt_notification *bt_notification_packet_end_create(
-		struct bt_packet *packet);
+extern struct bt_private_notification *
+bt_private_notification_packet_end_create(
+		struct bt_private_packet *private_packet);
 
 /*** BT_NOTIFICATION_TYPE_PACKET_BEGIN ***/
 extern struct bt_packet *bt_notification_packet_begin_get_packet(

--- a/include/babeltrace/graph/notification-stream.h
+++ b/include/babeltrace/graph/notification-stream.h
@@ -31,14 +31,16 @@
 extern "C" {
 #endif
 
+struct bt_private_notification;
 struct bt_notification;
+struct bt_private_stream;
 struct bt_stream;
 
-extern struct bt_notification *bt_notification_stream_begin_create(
-		struct bt_stream *stream);
+extern struct bt_private_notification *bt_private_notification_stream_begin_create(
+		struct bt_private_stream *private_stream);
 
-extern struct bt_notification *bt_notification_stream_end_create(
-		struct bt_stream *stream);
+extern struct bt_private_notification *bt_private_notification_stream_end_create(
+		struct bt_private_stream *private_stream);
 
 extern struct bt_stream *bt_notification_stream_begin_get_stream(
 		struct bt_notification *notification);

--- a/include/babeltrace/graph/notification.h
+++ b/include/babeltrace/graph/notification.h
@@ -31,6 +31,7 @@
 extern "C" {
 #endif
 
+struct bt_private_notification;
 struct bt_notification;
 
 /**
@@ -59,6 +60,12 @@ enum bt_notification_type {
  */
 extern enum bt_notification_type bt_notification_get_type(
 		struct bt_notification *notification);
+
+extern struct bt_notification *bt_notification_from_private(
+		struct bt_private_notification *private_notification);
+
+extern struct bt_notification *bt_notification_borrow_from_private(
+		struct bt_private_notification *private_notification);
 
 #ifdef __cplusplus
 }

--- a/lib/ctf-ir/packet.c
+++ b/lib/ctf-ir/packet.c
@@ -45,13 +45,21 @@ struct bt_stream *bt_packet_get_stream(struct bt_packet *packet)
 	return packet ? bt_get(packet->stream) : NULL;
 }
 
+struct bt_private_stream *bt_private_packet_get_private_stream(
+		struct bt_private_packet *priv_packet)
+{
+	return bt_private_stream_from_stream(
+		bt_packet_get_stream(
+			bt_packet_borrow_from_private(priv_packet)));
+}
+
 struct bt_field *bt_packet_get_header(
 		struct bt_packet *packet)
 {
 	return packet ? bt_get(packet->header) : NULL;
 }
 
-int bt_packet_set_header(struct bt_packet *packet,
+int bt_private_packet_set_header(struct bt_private_packet *priv_packet,
 		struct bt_field *header)
 {
 	int ret = 0;
@@ -59,6 +67,8 @@ int bt_packet_set_header(struct bt_packet *packet,
 	struct bt_stream_class *stream_class = NULL;
 	struct bt_field_type *header_field_type = NULL;
 	struct bt_field_type *expected_header_field_type = NULL;
+	struct bt_packet *packet =
+		bt_packet_borrow_from_private(priv_packet);
 
 	if (!packet) {
 		BT_LOGW_STR("Invalid parameter: packet is NULL.");
@@ -124,13 +134,15 @@ struct bt_field *bt_packet_get_context(
 	return packet ? bt_get(packet->context) : NULL;
 }
 
-int bt_packet_set_context(struct bt_packet *packet,
+int bt_private_packet_set_context(struct bt_private_packet *priv_packet,
 		struct bt_field *context)
 {
 	int ret = 0;
 	struct bt_stream_class *stream_class = NULL;
 	struct bt_field_type *context_field_type = NULL;
 	struct bt_field_type *expected_context_field_type = NULL;
+	struct bt_packet *packet =
+		bt_packet_borrow_from_private(priv_packet);
 
 	if (!packet) {
 		BT_LOGW_STR("Invalid parameter: packet is NULL.");
@@ -218,12 +230,14 @@ void bt_packet_destroy(struct bt_object *obj)
 	g_free(packet);
 }
 
-struct bt_packet *bt_packet_create(
-		struct bt_stream *stream)
+struct bt_private_packet *bt_private_packet_create(
+		struct bt_private_stream *priv_stream)
 {
 	struct bt_packet *packet = NULL;
 	struct bt_stream_class *stream_class = NULL;
 	struct bt_trace *trace = NULL;
+	struct bt_stream *stream =
+		bt_stream_borrow_from_private(priv_stream);
 
 	if (!stream) {
 		BT_LOGW_STR("Invalid parameter: stream is NULL.");
@@ -284,6 +298,11 @@ struct bt_packet *bt_packet_create(
 end:
 	BT_PUT(trace);
 	BT_PUT(stream_class);
+	return bt_private_packet_from_packet(packet);
+}
 
-	return packet;
+struct bt_packet *bt_packet_from_private(
+		struct bt_private_packet *private_packet)
+{
+	return bt_get(bt_packet_borrow_from_private(private_packet));
 }

--- a/lib/ctf-ir/stream.c
+++ b/lib/ctf-ir/stream.c
@@ -765,14 +765,16 @@ void component_destroy_listener(struct bt_component *component, void *data)
 }
 
 static
-struct bt_stream *bt_stream_create_with_id_no_check(
-		struct bt_stream_class *stream_class,
+struct bt_private_stream *bt_private_stream_create_with_id_no_check(
+		struct bt_private_stream_class *priv_stream_class,
 		const char *name, uint64_t id)
 {
 	int ret;
 	struct bt_stream *stream = NULL;
 	struct bt_trace *trace = NULL;
 	struct bt_ctf_writer *writer = NULL;
+	struct bt_stream_class *stream_class =
+		bt_stream_class_borrow_from_private(priv_stream_class);
 
 	if (!stream_class) {
 		BT_LOGW_STR("Invalid parameter: stream class is NULL.");
@@ -959,16 +961,18 @@ error:
 
 end:
 	bt_put(writer);
-	return stream;
+	return bt_private_stream_from_stream(stream);
 }
 
-struct bt_stream *bt_stream_create_with_id(
-		struct bt_stream_class *stream_class,
+struct bt_private_stream *bt_private_stream_create_with_id(
+		struct bt_private_stream_class *priv_stream_class,
 		const char *name, uint64_t id_param)
 {
 	struct bt_trace *trace;
-	struct bt_stream *stream = NULL;
+	struct bt_private_stream *stream = NULL;
 	int64_t id = (int64_t) id_param;
+	struct bt_stream_class *stream_class =
+		bt_stream_class_borrow_from_private(priv_stream_class);
 
 	if (!stream_class) {
 		BT_LOGW_STR("Invalid parameter: stream class is NULL.");
@@ -1001,19 +1005,19 @@ struct bt_stream *bt_stream_create_with_id(
 		goto end;
 	}
 
-	stream = bt_stream_create_with_id_no_check(stream_class,
+	stream = bt_private_stream_create_with_id_no_check(priv_stream_class,
 		name, id_param);
 
 end:
 	return stream;
 }
 
-struct bt_stream *bt_stream_create(
-		struct bt_stream_class *stream_class,
+struct bt_private_stream *bt_private_stream_create(
+		struct bt_private_stream_class *priv_stream_class,
 		const char *name)
 {
-	return bt_stream_create_with_id_no_check(stream_class,
-		name, -1ULL);
+	return bt_private_stream_create_with_id_no_check(
+		priv_stream_class, name, -1ULL);
 }
 
 struct bt_stream_class *bt_stream_get_class(
@@ -1032,10 +1036,20 @@ end:
 	return stream_class;
 }
 
-int bt_stream_get_discarded_events_count(
-		struct bt_stream *stream, uint64_t *count)
+struct bt_private_stream_class *bt_private_stream_get_private_class(
+		struct bt_private_stream *priv_stream)
+{
+	return bt_private_stream_class_from_stream_class(
+		bt_stream_get_class(
+			bt_stream_borrow_from_private(priv_stream)));
+}
+
+int bt_private_stream_get_discarded_events_count(
+		struct bt_private_stream *priv_stream, uint64_t *count)
 {
 	int ret = 0;
+	struct bt_stream *stream =
+		bt_stream_borrow_from_private(priv_stream);
 
 	if (!stream) {
 		BT_LOGW_STR("Invalid parameter: stream is NULL.");
@@ -1094,12 +1108,13 @@ end:
 	return ret;
 }
 
-void bt_stream_append_discarded_events(struct bt_stream *stream,
-		uint64_t event_count)
+void bt_private_stream_append_discarded_events(
+		struct bt_private_stream *priv_stream, uint64_t event_count)
 {
 	int ret;
 	uint64_t new_count;
 	struct bt_field *events_discarded_field = NULL;
+	struct bt_stream *stream = bt_stream_borrow_from_private(priv_stream);
 
 	if (!stream) {
 		BT_LOGW_STR("Invalid parameter: stream is NULL.");
@@ -1241,10 +1256,12 @@ end:
 	return ret;
 }
 
-int bt_stream_append_event(struct bt_stream *stream,
-		struct bt_event *event)
+int bt_private_stream_append_private_event(struct bt_private_stream *priv_stream,
+		struct bt_private_event *priv_event)
 {
 	int ret = 0;
+	struct bt_stream *stream = bt_stream_borrow_from_private(priv_stream);
+	struct bt_event *event = bt_event_borrow_from_private(priv_event);
 
 	if (!stream) {
 		BT_LOGW_STR("Invalid parameter: stream is NULL.");
@@ -1332,9 +1349,11 @@ error:
 	return ret;
 }
 
-struct bt_field *bt_stream_get_packet_context(struct bt_stream *stream)
+struct bt_field *bt_private_stream_get_packet_context(
+		struct bt_private_stream *priv_stream)
 {
 	struct bt_field *packet_context = NULL;
+	struct bt_stream *stream = bt_stream_borrow_from_private(priv_stream);
 
 	if (!stream) {
 		BT_LOGW_STR("Invalid parameter: stream is NULL.");
@@ -1356,11 +1375,12 @@ end:
 	return packet_context;
 }
 
-int bt_stream_set_packet_context(struct bt_stream *stream,
+int bt_private_stream_set_packet_context(struct bt_private_stream *priv_stream,
 		struct bt_field *field)
 {
 	int ret = 0;
 	struct bt_field_type *field_type;
+	struct bt_stream *stream = bt_stream_borrow_from_private(priv_stream);
 
 	if (!stream) {
 		BT_LOGW_STR("Invalid parameter: stream is NULL.");
@@ -1398,9 +1418,11 @@ end:
 	return ret;
 }
 
-struct bt_field *bt_stream_get_packet_header(struct bt_stream *stream)
+struct bt_field *bt_private_stream_get_packet_header(
+		struct bt_private_stream *priv_stream)
 {
 	struct bt_field *packet_header = NULL;
+	struct bt_stream *stream = bt_stream_borrow_from_private(priv_stream);
 
 	if (!stream) {
 		BT_LOGW_STR("Invalid parameter: stream is NULL.");
@@ -1422,12 +1444,13 @@ end:
 	return packet_header;
 }
 
-int bt_stream_set_packet_header(struct bt_stream *stream,
+int bt_private_stream_set_packet_header(struct bt_private_stream *priv_stream,
 		struct bt_field *field)
 {
 	int ret = 0;
 	struct bt_trace *trace = NULL;
 	struct bt_field_type *field_type = NULL;
+	struct bt_stream *stream = bt_stream_borrow_from_private(priv_stream);
 
 	if (!stream) {
 		BT_LOGW_STR("Invalid parameter: stream is NULL.");
@@ -1497,7 +1520,7 @@ void reset_structure_field(struct bt_field *structure, const char *name)
 	}
 }
 
-int bt_stream_flush(struct bt_stream *stream)
+int bt_private_stream_flush(struct bt_private_stream *priv_stream)
 {
 	int ret = 0;
 	size_t i;
@@ -1505,6 +1528,7 @@ int bt_stream_flush(struct bt_stream *stream)
 	struct bt_trace *trace;
 	enum bt_byte_order native_byte_order;
 	bool has_packet_size = false;
+	struct bt_stream *stream = bt_stream_borrow_from_private(priv_stream);
 
 	if (!stream) {
 		BT_LOGW_STR("Invalid parameter: stream is NULL.");
@@ -2037,4 +2061,10 @@ int64_t bt_stream_get_id(struct bt_stream *stream)
 
 end:
 	return ret;
+}
+
+struct bt_stream *bt_stream_from_private(
+		struct bt_private_stream *private_stream)
+{
+	return bt_get(bt_stream_borrow_from_private(private_stream));
 }

--- a/lib/graph/iterator.c
+++ b/lib/graph/iterator.c
@@ -942,7 +942,7 @@ int add_action_push_notif_stream_begin(
 		struct bt_stream *stream)
 {
 	int ret = 0;
-	struct bt_notification *stream_begin_notif = NULL;
+	struct bt_private_notification *priv_stream_begin_notif = NULL;
 
 	if (!is_subscribed_to_notification_type(iterator,
 			BT_NOTIFICATION_TYPE_STREAM_BEGIN)) {
@@ -953,13 +953,17 @@ int add_action_push_notif_stream_begin(
 	}
 
 	assert(stream);
-	stream_begin_notif = bt_notification_stream_begin_create(stream);
-	if (!stream_begin_notif) {
+	priv_stream_begin_notif =
+		bt_private_notification_stream_begin_create(
+			bt_private_stream_from_stream(stream));
+	if (!priv_stream_begin_notif) {
 		BT_LOGE_STR("Cannot create stream beginning notification.");
 		goto error;
 	}
 
-	add_action_push_notif(iterator, stream_begin_notif);
+
+	add_action_push_notif(iterator,
+		bt_notification_borrow_from_private(priv_stream_begin_notif));
 	BT_LOGV("Added \"push stream beginning notification\" action: "
 		"stream-addr=%p, stream-name=\"%s\"",
 		stream, bt_stream_get_name(stream));
@@ -969,7 +973,7 @@ error:
 	ret = -1;
 
 end:
-	bt_put(stream_begin_notif);
+	bt_put(priv_stream_begin_notif);
 	return ret;
 }
 
@@ -979,7 +983,7 @@ int add_action_push_notif_stream_end(
 		struct bt_stream *stream)
 {
 	int ret = 0;
-	struct bt_notification *stream_end_notif = NULL;
+	struct bt_private_notification *priv_stream_end_notif = NULL;
 
 	if (!is_subscribed_to_notification_type(iterator,
 			BT_NOTIFICATION_TYPE_STREAM_END)) {
@@ -990,13 +994,16 @@ int add_action_push_notif_stream_end(
 	}
 
 	assert(stream);
-	stream_end_notif = bt_notification_stream_end_create(stream);
-	if (!stream_end_notif) {
+	priv_stream_end_notif =
+		bt_private_notification_stream_end_create(
+			bt_private_stream_from_stream(stream));
+	if (!priv_stream_end_notif) {
 		BT_LOGE_STR("Cannot create stream end notification.");
 		goto error;
 	}
 
-	add_action_push_notif(iterator, stream_end_notif);
+	add_action_push_notif(iterator,
+		bt_notification_borrow_from_private(priv_stream_end_notif));
 	BT_LOGV("Added \"push stream end notification\" action: "
 		"stream-addr=%p, stream-name=\"%s\"",
 		stream, bt_stream_get_name(stream));
@@ -1006,7 +1013,7 @@ error:
 	ret = -1;
 
 end:
-	bt_put(stream_end_notif);
+	bt_put(priv_stream_end_notif);
 	return ret;
 }
 
@@ -1016,7 +1023,7 @@ int add_action_push_notif_packet_begin(
 		struct bt_packet *packet)
 {
 	int ret = 0;
-	struct bt_notification *packet_begin_notif = NULL;
+	struct bt_private_notification *priv_packet_begin_notif = NULL;
 
 	if (!is_subscribed_to_notification_type(iterator,
 			BT_NOTIFICATION_TYPE_PACKET_BEGIN)) {
@@ -1027,13 +1034,16 @@ int add_action_push_notif_packet_begin(
 	}
 
 	assert(packet);
-	packet_begin_notif = bt_notification_packet_begin_create(packet);
-	if (!packet_begin_notif) {
+	priv_packet_begin_notif =
+		bt_private_notification_packet_begin_create(
+			bt_private_packet_from_packet(packet));
+	if (!priv_packet_begin_notif) {
 		BT_LOGE_STR("Cannot create packet beginning notification.");
 		goto error;
 	}
 
-	add_action_push_notif(iterator, packet_begin_notif);
+	add_action_push_notif(iterator,
+		bt_notification_borrow_from_private(priv_packet_begin_notif));
 	BT_LOGV("Added \"push packet beginning notification\" action: "
 		"packet-addr=%p", packet);
 	goto end;
@@ -1042,7 +1052,7 @@ error:
 	ret = -1;
 
 end:
-	bt_put(packet_begin_notif);
+	bt_put(priv_packet_begin_notif);
 	return ret;
 }
 
@@ -1052,7 +1062,7 @@ int add_action_push_notif_packet_end(
 		struct bt_packet *packet)
 {
 	int ret = 0;
-	struct bt_notification *packet_end_notif = NULL;
+	struct bt_private_notification *priv_packet_end_notif = NULL;
 
 	if (!is_subscribed_to_notification_type(iterator,
 			BT_NOTIFICATION_TYPE_PACKET_END)) {
@@ -1063,13 +1073,15 @@ int add_action_push_notif_packet_end(
 	}
 
 	assert(packet);
-	packet_end_notif = bt_notification_packet_end_create(packet);
-	if (!packet_end_notif) {
+	priv_packet_end_notif = bt_private_notification_packet_end_create(
+			bt_private_packet_from_packet(packet));
+	if (!priv_packet_end_notif) {
 		BT_LOGE_STR("Cannot create packet end notification.");
 		goto error;
 	}
 
-	add_action_push_notif(iterator, packet_end_notif);
+	add_action_push_notif(iterator,
+		bt_notification_borrow_from_private(priv_packet_end_notif));
 	BT_LOGV("Added \"push packet end notification\" action: "
 		"packet-addr=%p", packet);
 	goto end;
@@ -1078,7 +1090,7 @@ error:
 	ret = -1;
 
 end:
-	bt_put(packet_end_notif);
+	bt_put(priv_packet_end_notif);
 	return ret;
 }
 

--- a/lib/graph/notification/event.c
+++ b/lib/graph/notification/event.c
@@ -163,11 +163,13 @@ bool event_has_trace(struct bt_event *event)
 	return bt_stream_class_borrow_trace(stream_class) != NULL;
 }
 
-struct bt_notification *bt_notification_event_create(struct bt_event *event,
+struct bt_private_notification *bt_private_notification_event_create(
+		struct bt_private_event *priv_event,
 		struct bt_clock_class_priority_map *cc_prio_map)
 {
 	struct bt_notification_event *notification = NULL;
 	struct bt_event_class *event_class;
+	struct bt_event *event = bt_event_borrow_from_private(priv_event);
 
 	if (!event) {
 		BT_LOGW_STR("Invalid parameter: event is NULL.");
@@ -258,7 +260,7 @@ error:
 
 end:
 	bt_put(cc_prio_map);
-	return &notification->parent;
+	return bt_private_notification_from_notification(&notification->parent);
 }
 
 struct bt_event *bt_notification_event_get_event(

--- a/lib/graph/notification/inactivity.c
+++ b/lib/graph/notification/inactivity.c
@@ -49,7 +49,7 @@ void bt_notification_inactivity_destroy(struct bt_object *obj)
 	g_free(notification);
 }
 
-struct bt_notification *bt_notification_inactivity_create(
+struct bt_private_notification *bt_private_notification_inactivity_create(
 		struct bt_clock_class_priority_map *cc_prio_map)
 {
 	struct bt_notification_inactivity *notification;
@@ -98,7 +98,7 @@ error:
 
 end:
 	bt_put(cc_prio_map);
-	return ret_notif;
+	return bt_private_notification_from_notification(ret_notif);
 }
 
 extern struct bt_clock_class_priority_map *
@@ -165,14 +165,16 @@ end:
 	return clock_value;
 }
 
-int bt_notification_inactivity_set_clock_value(
-		struct bt_notification *notification,
+int bt_private_notification_inactivity_set_clock_value(
+		struct bt_private_notification *priv_notif,
 		struct bt_clock_value *clock_value)
 {
 	int ret = 0;
 	uint64_t prio;
 	struct bt_clock_class *clock_class = NULL;
 	struct bt_notification_inactivity *inactivity_notification;
+	struct bt_notification *notification =
+		bt_notification_borrow_from_private(priv_notif);
 
 	if (!notification) {
 		BT_LOGW_STR("Invalid parameter: notification is NULL.");

--- a/lib/graph/notification/notification.c
+++ b/lib/graph/notification/notification.c
@@ -42,3 +42,15 @@ enum bt_notification_type bt_notification_get_type(
 {
 	return notification ? notification->type : BT_NOTIFICATION_TYPE_UNKNOWN;
 }
+
+struct bt_notification *bt_notification_from_private(
+		struct bt_private_notification *private_notification)
+{
+	return bt_get(private_notification);
+}
+
+struct bt_notification *bt_notification_borrow_from_private(
+		struct bt_private_notification *private_notification)
+{
+	return (void *) private_notification;
+}

--- a/lib/graph/notification/packet.c
+++ b/lib/graph/notification/packet.c
@@ -62,12 +62,13 @@ void bt_notification_packet_end_destroy(struct bt_object *obj)
 	g_free(notification);
 }
 
-struct bt_notification *bt_notification_packet_begin_create(
-		struct bt_packet *packet)
+struct bt_private_notification *bt_private_notification_packet_begin_create(
+		struct bt_private_packet *priv_packet)
 {
 	struct bt_notification_packet_begin *notification;
 	struct bt_stream *stream;
 	struct bt_stream_class *stream_class;
+	struct bt_packet *packet = bt_packet_borrow_from_private(priv_packet);
 
 	if (!packet) {
 		BT_LOGW_STR("Invalid parameter: packet is NULL.");
@@ -104,7 +105,7 @@ struct bt_notification *bt_notification_packet_begin_create(
 		stream_class,
 		bt_stream_class_get_name(stream_class),
 		bt_stream_class_get_id(stream_class), notification);
-	return &notification->parent;
+	return bt_private_notification_from_notification(&notification->parent);
 error:
 	return NULL;
 }
@@ -135,12 +136,13 @@ end:
 	return ret;
 }
 
-struct bt_notification *bt_notification_packet_end_create(
-		struct bt_packet *packet)
+struct bt_private_notification *bt_private_notification_packet_end_create(
+		struct bt_private_packet *priv_packet)
 {
 	struct bt_notification_packet_end *notification;
 	struct bt_stream *stream;
 	struct bt_stream_class *stream_class;
+	struct bt_packet *packet = bt_packet_borrow_from_private(priv_packet);
 
 	if (!packet) {
 		BT_LOGW_STR("Invalid parameter: packet is NULL.");
@@ -177,7 +179,7 @@ struct bt_notification *bt_notification_packet_end_create(
 		stream_class,
 		bt_stream_class_get_name(stream_class),
 		bt_stream_class_get_id(stream_class), notification);
-	return &notification->parent;
+	return bt_private_notification_from_notification(&notification->parent);
 error:
 	return NULL;
 }

--- a/lib/graph/notification/stream.c
+++ b/lib/graph/notification/stream.c
@@ -46,11 +46,12 @@ void bt_notification_stream_end_destroy(struct bt_object *obj)
 	g_free(notification);
 }
 
-struct bt_notification *bt_notification_stream_end_create(
-		struct bt_stream *stream)
+struct bt_private_notification *bt_private_notification_stream_end_create(
+		struct bt_private_stream *priv_stream)
 {
 	struct bt_notification_stream_end *notification;
 	struct bt_stream_class *stream_class;
+	struct bt_stream *stream = bt_stream_borrow_from_private(priv_stream);
 
 	if (!stream) {
 		BT_LOGW_STR("Invalid parameter: stream is NULL.");
@@ -97,7 +98,7 @@ struct bt_notification *bt_notification_stream_end_create(
 		stream_class,
 		bt_stream_class_get_name(stream_class),
 		bt_stream_class_get_id(stream_class), notification);
-	return &notification->parent;
+	return bt_private_notification_from_notification(&notification->parent);
 error:
 	return NULL;
 }
@@ -142,11 +143,12 @@ void bt_notification_stream_begin_destroy(struct bt_object *obj)
 	g_free(notification);
 }
 
-struct bt_notification *bt_notification_stream_begin_create(
-		struct bt_stream *stream)
+struct bt_private_notification *bt_private_notification_stream_begin_create(
+		struct bt_private_stream *priv_stream)
 {
 	struct bt_notification_stream_begin *notification;
 	struct bt_stream_class *stream_class;
+	struct bt_stream *stream = bt_stream_borrow_from_private(priv_stream);
 
 	if (!stream) {
 		BT_LOGW_STR("Invalid parameter: stream is NULL.");
@@ -193,7 +195,7 @@ struct bt_notification *bt_notification_stream_begin_create(
 		stream_class,
 		bt_stream_class_get_name(stream_class),
 		bt_stream_class_get_id(stream_class), notification);
-	return &notification->parent;
+	return bt_private_notification_from_notification(&notification->parent);
 error:
 	return NULL;
 }

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = libctfcopytrace ctf text utils
+SUBDIRS = ctf text utils
 
 if ENABLE_DEBUG_INFO
 SUBDIRS += lttng-utils

--- a/plugins/ctf/Makefile.am
+++ b/plugins/ctf/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = common fs-src fs-sink lttng-live
+SUBDIRS = common fs-src lttng-live
 
 noinst_HEADERS = print.h
 
@@ -15,7 +15,6 @@ babeltrace_plugin_ctf_la_LDFLAGS = \
 babeltrace_plugin_ctf_la_LIBADD = \
 	fs-src/libbabeltrace-plugin-ctf-fs.la \
 	lttng-live/libbabeltrace-plugin-ctf-lttng-live.la \
-	fs-sink/libbabeltrace-plugin-ctf-writer.la \
 	common/libbabeltrace-plugin-ctf-common.la
 
 if !ENABLE_BUILT_IN_PLUGINS

--- a/plugins/ctf/common/metadata/ast.h
+++ b/plugins/ctf/common/metadata/ast.h
@@ -317,7 +317,7 @@ struct ctf_visitor_generate_ir *ctf_visitor_generate_ir_create(
 void ctf_visitor_generate_ir_destroy(struct ctf_visitor_generate_ir *visitor);
 
 BT_HIDDEN
-struct bt_trace *ctf_visitor_generate_ir_get_trace(
+struct bt_private_trace *ctf_visitor_generate_ir_get_trace(
 		struct ctf_visitor_generate_ir *visitor);
 
 BT_HIDDEN

--- a/plugins/ctf/common/metadata/decoder.c
+++ b/plugins/ctf/common/metadata/decoder.c
@@ -552,7 +552,7 @@ end:
 }
 
 BT_HIDDEN
-struct bt_trace *ctf_metadata_decoder_get_trace(
+struct bt_private_trace *ctf_metadata_decoder_get_private_trace(
 		struct ctf_metadata_decoder *mdec)
 {
 	return ctf_visitor_generate_ir_get_trace(mdec->visitor);

--- a/plugins/ctf/common/metadata/decoder.h
+++ b/plugins/ctf/common/metadata/decoder.h
@@ -18,7 +18,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-struct bt_trace;
+struct bt_private_trace;
 
 /* A CTF metadata decoder object */
 struct ctf_metadata_decoder;
@@ -96,7 +96,7 @@ enum ctf_metadata_decoder_status ctf_metadata_decoder_decode(
  * ctf_metadata_decoder_destroy().
  */
 BT_HIDDEN
-struct bt_trace *ctf_metadata_decoder_get_trace(
+struct bt_private_trace *ctf_metadata_decoder_get_private_trace(
 		struct ctf_metadata_decoder *metadata_decoder);
 
 /*

--- a/plugins/ctf/common/notif-iter/notif-iter.h
+++ b/plugins/ctf/common/notif-iter/notif-iter.h
@@ -226,8 +226,8 @@ struct bt_notif_iter_medium_ops {
 	 * @returns		Stream instance (weak reference) or
 	 *			\c NULL on error
 	 */
-	struct bt_stream * (* get_stream)(
-			struct bt_stream_class *stream_class,
+	struct bt_private_stream * (* get_stream)(
+			struct bt_private_stream_class *priv_stream_class,
 			uint64_t stream_id, void *data);
 };
 
@@ -277,7 +277,7 @@ struct bt_notif_iter_notif_event {
  *				success, or \c NULL on error
  */
 BT_HIDDEN
-struct bt_notif_iter *bt_notif_iter_create(struct bt_trace *trace,
+struct bt_notif_iter *bt_notif_iter_create(struct bt_private_trace *priv_trace,
 	size_t max_request_sz, struct bt_notif_iter_medium_ops medops,
 	void *medops_data);
 

--- a/plugins/ctf/common/utils/utils.c
+++ b/plugins/ctf/common/utils/utils.c
@@ -27,14 +27,18 @@
 
 #include "utils.h"
 
-struct bt_stream_class *ctf_utils_stream_class_from_packet_header(
-		struct bt_trace *trace,
+struct bt_private_stream_class *ctf_utils_stream_class_from_packet_header(
+		struct bt_private_trace *trace,
 		struct bt_field *packet_header_field)
 {
 	struct bt_field *stream_id_field = NULL;
-	struct bt_stream_class *stream_class = NULL;
+	struct bt_private_stream_class *stream_class = NULL;
 	uint64_t stream_id = -1ULL;
 	int ret;
+	struct bt_trace *pub_trace =
+		bt_trace_from_private(trace);
+
+	bt_put(pub_trace);
 
 	if (!packet_header_field) {
 		goto single_stream_class;
@@ -55,14 +59,17 @@ struct bt_stream_class *ctf_utils_stream_class_from_packet_header(
 	if (stream_id == -1ULL) {
 single_stream_class:
 		/* Single stream class */
-		if (bt_trace_get_stream_class_count(trace) == 0) {
+		if (bt_trace_get_stream_class_count(pub_trace) == 0) {
 			goto end;
 		}
 
-		stream_class = bt_trace_get_stream_class_by_index(trace, 0);
+		stream_class =
+			bt_private_trace_get_private_stream_class_by_index(
+				trace, 0);
 	} else {
-		stream_class = bt_trace_get_stream_class_by_id(trace,
-			stream_id);
+		stream_class =
+			bt_private_trace_get_private_stream_class_by_id(trace,
+				stream_id);
 	}
 
 end:

--- a/plugins/ctf/common/utils/utils.h
+++ b/plugins/ctf/common/utils/utils.h
@@ -28,8 +28,8 @@
 #include <babeltrace/babeltrace.h>
 #include <babeltrace/babeltrace-internal.h>
 
-struct bt_stream_class *ctf_utils_stream_class_from_packet_header(
-		struct bt_trace *trace,
+struct bt_private_stream_class *ctf_utils_stream_class_from_packet_header(
+		struct bt_private_trace *trace,
 		struct bt_field *packet_header_field);
 
 #endif /* CTF_UTILS_H */

--- a/plugins/ctf/fs-sink/write.c
+++ b/plugins/ctf/fs-sink/write.c
@@ -61,7 +61,7 @@ gboolean empty_streams_ht(gpointer key, gpointer value, gpointer user_data)
 	int ret;
 	struct bt_stream *writer_stream = value;
 
-	ret = bt_stream_flush(writer_stream);
+	ret = bt_private_stream_flush(writer_stream);
 	if (ret) {
 		BT_LOGD_STR("Failed to flush stream while emptying hash table.");
 	}
@@ -109,7 +109,7 @@ struct bt_stream_class *insert_new_stream_class(
 		struct bt_stream_class *stream_class)
 {
 	struct bt_stream_class *writer_stream_class = NULL;
-	struct bt_trace *trace = NULL, *writer_trace = NULL;
+	struct bt_private_trace *trace = NULL, *writer_trace = NULL;
 	struct bt_ctf_writer *ctf_writer = fs_writer->writer;
 	enum bt_component_status ret;
 

--- a/plugins/ctf/fs-src/data-stream-file.c
+++ b/plugins/ctf/fs-src/data-stream-file.c
@@ -173,15 +173,16 @@ end:
 }
 
 static
-struct bt_stream *medop_get_stream(
-		struct bt_stream_class *stream_class, uint64_t stream_id,
-		void *data)
+struct bt_private_stream *medop_get_stream(
+		struct bt_private_stream_class *stream_class,
+		uint64_t stream_id, void *data)
 {
 	struct ctf_fs_ds_file *ds_file = data;
-	struct bt_stream_class *ds_file_stream_class;
-	struct bt_stream *stream = NULL;
+	struct bt_private_stream_class *ds_file_stream_class;
+	struct bt_private_stream *stream = NULL;
 
-	ds_file_stream_class = bt_stream_get_class(ds_file->stream);
+	ds_file_stream_class = bt_private_stream_get_private_class(
+		ds_file->stream);
 	bt_put(ds_file_stream_class);
 
 	if (stream_class != ds_file_stream_class) {
@@ -764,7 +765,7 @@ BT_HIDDEN
 struct ctf_fs_ds_file *ctf_fs_ds_file_create(
 		struct ctf_fs_trace *ctf_fs_trace,
 		struct bt_notif_iter *notif_iter,
-		struct bt_stream *stream, const char *path)
+		struct bt_private_stream *stream, const char *path)
 {
 	int ret;
 	const size_t page_size = bt_common_get_page_size();

--- a/plugins/ctf/fs-src/data-stream-file.h
+++ b/plugins/ctf/fs-src/data-stream-file.h
@@ -89,7 +89,7 @@ struct ctf_fs_ds_file {
 	struct ctf_fs_file *file;
 
 	/* Owned by this */
-	struct bt_stream *stream;
+	struct bt_private_stream *stream;
 
 	/* Owned by this */
 	struct bt_clock_class_priority_map *cc_prio_map;
@@ -124,7 +124,7 @@ BT_HIDDEN
 struct ctf_fs_ds_file *ctf_fs_ds_file_create(
 		struct ctf_fs_trace *ctf_fs_trace,
 		struct bt_notif_iter *notif_iter,
-		struct bt_stream *stream, const char *path);
+		struct bt_private_stream *stream, const char *path);
 
 BT_HIDDEN
 int ctf_fs_ds_file_get_packet_header_context_fields(

--- a/plugins/ctf/fs-src/fs.h
+++ b/plugins/ctf/fs-src/fs.h
@@ -49,7 +49,7 @@ struct ctf_fs_file {
 
 struct ctf_fs_metadata {
 	/* Owned by this */
-	struct bt_trace *trace;
+	struct bt_private_trace *trace;
 
 	/* Owned by this */
 	char *text;
@@ -102,10 +102,10 @@ struct ctf_fs_ds_file_group {
 	GPtrArray *ds_file_infos;
 
 	/* Owned by this */
-	struct bt_stream_class *stream_class;
+	struct bt_private_stream_class *stream_class;
 
 	/* Owned by this */
-	struct bt_stream *stream;
+	struct bt_private_stream *stream;
 
 	/* Stream (instance) ID; -1ULL means none */
 	uint64_t stream_id;

--- a/plugins/ctf/fs-src/metadata.c
+++ b/plugins/ctf/fs-src/metadata.c
@@ -119,7 +119,7 @@ int ctf_fs_metadata_set_trace(struct ctf_fs_trace *ctf_fs_trace,
 		goto end;
 	}
 
-	ctf_fs_trace->metadata->trace = ctf_metadata_decoder_get_trace(
+	ctf_fs_trace->metadata->trace = ctf_metadata_decoder_get_private_trace(
 		metadata_decoder);
 	assert(ctf_fs_trace->metadata->trace);
 

--- a/plugins/ctf/fs-src/query.c
+++ b/plugins/ctf/fs-src/query.c
@@ -228,14 +228,16 @@ end:
 }
 
 static
-int add_stream_ids(struct bt_value *info, struct bt_stream *stream)
+int add_stream_ids(struct bt_value *info, struct bt_private_stream *stream)
 {
 	int ret = 0;
 	int64_t stream_class_id, stream_instance_id;
 	enum bt_value_status status;
 	struct bt_stream_class *stream_class = NULL;
+	struct bt_stream *pub_stream = bt_stream_from_private(stream);
 
-	stream_instance_id = bt_stream_get_id(stream);
+	bt_put(pub_stream);
+	stream_instance_id = bt_stream_get_id(pub_stream);
 	if (stream_instance_id != -1) {
 		status = bt_value_map_insert_integer(info, "id",
 				stream_instance_id);
@@ -245,7 +247,7 @@ int add_stream_ids(struct bt_value *info, struct bt_stream *stream)
 		}
 	}
 
-	stream_class = bt_stream_get_class(stream);
+	stream_class = bt_stream_get_class(pub_stream);
 	if (!stream_class) {
 		ret = -1;
 		goto end;

--- a/plugins/ctf/lttng-live/data-stream.c
+++ b/plugins/ctf/lttng-live/data-stream.c
@@ -72,26 +72,29 @@ enum bt_notif_iter_medium_status medop_request_bytes(
 }
 
 static
-struct bt_stream *medop_get_stream(
-		struct bt_stream_class *stream_class,
+struct bt_private_stream *medop_get_stream(
+		struct bt_private_stream_class *stream_class,
 		uint64_t stream_id, void *data)
 {
 	struct lttng_live_stream_iterator *lttng_live_stream = data;
+	struct bt_stream_class *pub_stream_class =
+		bt_stream_class_from_private(stream_class);
 
+	bt_put(pub_stream_class);
 	if (!lttng_live_stream->stream) {
 		int64_t stream_class_id =
-			bt_stream_class_get_id(stream_class);
+			bt_stream_class_get_id(pub_stream_class);
 
 		BT_LOGD("Creating stream %s (ID: %" PRIu64 ") out of stream class %" PRId64,
 			lttng_live_stream->name, stream_id, stream_class_id);
 
 		if (stream_id == -1ULL) {
 			/* No stream ID */
-			lttng_live_stream->stream = bt_stream_create(
+			lttng_live_stream->stream = bt_private_stream_create(
 				stream_class, lttng_live_stream->name);
 		} else {
 			lttng_live_stream->stream =
-				bt_stream_create_with_id(stream_class,
+				bt_private_stream_create_with_id(stream_class,
 					lttng_live_stream->name, stream_id);
 		}
 

--- a/plugins/ctf/lttng-live/lttng-live-internal.h
+++ b/plugins/ctf/lttng-live/lttng-live-internal.h
@@ -69,7 +69,7 @@ struct lttng_live_stream_iterator_generic {
 struct lttng_live_stream_iterator {
 	struct lttng_live_stream_iterator_generic p;
 
-	struct bt_stream *stream;
+	struct bt_private_stream *stream;
 	struct lttng_live_trace *trace;
 	struct bt_private_port *port;	/* weak ref. */
 
@@ -138,7 +138,7 @@ struct lttng_live_trace {
 
 	uint64_t id;	/* ctf trace ID within the session. */
 
-	struct bt_trace *trace;
+	struct bt_private_trace *trace;
 
 	struct lttng_live_metadata *metadata;
 	struct bt_clock_class_priority_map *cc_prio_map;

--- a/plugins/ctf/lttng-live/lttng-live.c
+++ b/plugins/ctf/lttng-live/lttng-live.c
@@ -212,7 +212,7 @@ void lttng_live_destroy_trace(struct bt_object *obj)
 	if (trace->trace) {
 		int retval;
 
-		retval = bt_trace_set_is_static(trace->trace);
+		retval = bt_private_trace_set_is_static(trace->trace);
 		assert(!retval);
 		BT_PUT(trace->trace);
 	}
@@ -564,7 +564,7 @@ enum bt_lttng_live_iterator_status emit_inactivity_notification(
 	struct lttng_live_trace *trace;
 	struct bt_clock_class *clock_class = NULL;
 	struct bt_clock_value *clock_value = NULL;
-	struct bt_notification *notif = NULL;
+	struct bt_private_notification *notif = NULL;
 	int retval;
 
 	trace = lttng_live_stream->trace;
@@ -579,15 +579,16 @@ enum bt_lttng_live_iterator_status emit_inactivity_notification(
 	if (!clock_value) {
 		goto error;
 	}
-	notif = bt_notification_inactivity_create(trace->cc_prio_map);
+	notif = bt_private_notification_inactivity_create(trace->cc_prio_map);
 	if (!notif) {
 		goto error;
 	}
-	retval = bt_notification_inactivity_set_clock_value(notif, clock_value);
+	retval = bt_private_notification_inactivity_set_clock_value(notif,
+		clock_value);
 	if (retval) {
 		goto error;
 	}
-	*notification = notif;
+	*notification = bt_notification_borrow_from_private(notif);
 end:
 	bt_put(clock_value);
 	bt_put(clock_class);

--- a/plugins/ctf/lttng-live/metadata.c
+++ b/plugins/ctf/lttng-live/metadata.c
@@ -61,19 +61,21 @@ enum bt_lttng_live_iterator_status lttng_live_update_clock_map(
 			BT_LTTNG_LIVE_ITERATOR_STATUS_OK;
 	size_t i;
 	int count, ret;
+	struct bt_trace *pub_trace = bt_trace_from_private(trace->trace);
 
+	bt_put(pub_trace);
 	BT_PUT(trace->cc_prio_map);
 	trace->cc_prio_map = bt_clock_class_priority_map_create();
 	if (!trace->cc_prio_map) {
 		goto error;
 	}
 
-	count = bt_trace_get_clock_class_count(trace->trace);
+	count = bt_trace_get_clock_class_count(pub_trace);
 	assert(count >= 0);
 
 	for (i = 0; i < count; i++) {
 		struct bt_clock_class *clock_class =
-			bt_trace_get_clock_class_by_index(trace->trace, i);
+			bt_trace_get_clock_class_by_index(pub_trace, i);
 
 		assert(clock_class);
 		ret = bt_clock_class_priority_map_add_clock_class(
@@ -196,7 +198,8 @@ enum bt_lttng_live_iterator_status lttng_live_metadata_update(
 	switch (decoder_status) {
 	case CTF_METADATA_DECODER_STATUS_OK:
 		BT_PUT(trace->trace);
-		trace->trace = ctf_metadata_decoder_get_trace(metadata->decoder);
+		trace->trace = ctf_metadata_decoder_get_private_trace(
+			metadata->decoder);
 		trace->new_metadata_needed = false;
 		status = lttng_live_update_clock_map(trace);
 		if (status != BT_LTTNG_LIVE_ITERATOR_STATUS_OK) {

--- a/plugins/ctf/plugin.c
+++ b/plugins/ctf/plugin.c
@@ -54,12 +54,14 @@ BT_PLUGIN_SOURCE_COMPONENT_CLASS_NOTIFICATION_ITERATOR_FINALIZE_METHOD(fs,
 	ctf_fs_iterator_finalize);
 
 /* ctf.fs sink */
+/*
 BT_PLUGIN_SINK_COMPONENT_CLASS(fs, writer_run);
 BT_PLUGIN_SINK_COMPONENT_CLASS_INIT_METHOD(fs, writer_component_init);
 BT_PLUGIN_SINK_COMPONENT_CLASS_PORT_CONNECTED_METHOD(fs,
 		writer_component_port_connected);
 BT_PLUGIN_SINK_COMPONENT_CLASS_FINALIZE_METHOD(fs, writer_component_finalize);
 BT_PLUGIN_SINK_COMPONENT_CLASS_DESCRIPTION(fs, "Write CTF traces to the file system.");
+*/
 
 /* ctf.lttng-live source */
 BT_PLUGIN_SOURCE_COMPONENT_CLASS_WITH_ID(auto, lttng_live, "lttng-live",

--- a/plugins/utils/Makefile.am
+++ b/plugins/utils/Makefile.am
@@ -1,6 +1,6 @@
 AM_CPPFLAGS += -I$(top_srcdir)/plugins
 
-SUBDIRS = dummy counter trimmer muxer .
+SUBDIRS = dummy counter muxer .
 
 plugindir = "$(PLUGINSDIR)"
 plugin_LTLIBRARIES = babeltrace-plugin-utils.la
@@ -12,13 +12,11 @@ babeltrace_plugin_utils_la_LDFLAGS = \
 babeltrace_plugin_utils_la_LIBADD = \
 	dummy/libbabeltrace-plugin-dummy-cc.la \
 	counter/libbabeltrace-plugin-counter-cc.la \
-	trimmer/libbabeltrace-plugin-trimmer.la \
 	muxer/libbabeltrace-plugin-muxer.la
 
 if !ENABLE_BUILT_IN_PLUGINS
 babeltrace_plugin_utils_la_LIBADD += \
 	$(top_builddir)/lib/libbabeltrace.la \
-	$(top_builddir)/plugins/libctfcopytrace/libctfcopytrace.la \
 	$(top_builddir)/common/libbabeltrace-common.la \
 	$(top_builddir)/logging/libbabeltrace-logging.la
 endif

--- a/plugins/utils/plugin.c
+++ b/plugins/utils/plugin.c
@@ -55,6 +55,7 @@ BT_PLUGIN_SINK_COMPONENT_CLASS_DESCRIPTION(counter,
 	"Count notifications and print the results.");
 
 /* flt.utils.trimmer */
+/*
 BT_PLUGIN_FILTER_COMPONENT_CLASS(trimmer, trimmer_iterator_next);
 BT_PLUGIN_FILTER_COMPONENT_CLASS_DESCRIPTION(trimmer,
 	"Keep notifications that occur within a specific time range.");
@@ -64,6 +65,7 @@ BT_PLUGIN_FILTER_COMPONENT_CLASS_NOTIFICATION_ITERATOR_INIT_METHOD(trimmer,
 	trimmer_iterator_init);
 BT_PLUGIN_FILTER_COMPONENT_CLASS_NOTIFICATION_ITERATOR_FINALIZE_METHOD(trimmer,
 	trimmer_iterator_finalize);
+*/
 
 /* flt.utils.muxer */
 BT_PLUGIN_FILTER_COMPONENT_CLASS(muxer, muxer_notif_iter_next);

--- a/tests/lib/test_ctf_ir_ref.c
+++ b/tests/lib/test_ctf_ir_ref.c
@@ -38,11 +38,11 @@
 
 struct user {
 	struct bt_ctf_writer *writer;
-	struct bt_trace *tc;
-	struct bt_stream_class *sc;
-	struct bt_event_class *ec;
-	struct bt_stream *stream;
-	struct bt_event *event;
+	struct bt_private_trace *tc;
+	struct bt_private_stream_class *sc;
+	struct bt_private_event_class *ec;
+	struct bt_private_stream *stream;
+	struct bt_private_event *event;
 };
 
 const char *user_names[] = {
@@ -122,14 +122,14 @@ error:
  *     - uint16_t payload_16;
  *     - uint32_t payload_32;
  */
-static struct bt_event_class *create_simple_event(const char *name)
+static struct bt_private_event_class *create_simple_event(const char *name)
 {
 	int ret;
-	struct bt_event_class *event = NULL;
+	struct bt_private_event_class *event = NULL;
 	struct bt_field_type *payload = NULL;
 
 	assert(name);
-	event = bt_event_class_create(name);
+	event = bt_private_event_class_create(name);
 	if (!event) {
 		diag("Failed to create simple event");
 		goto error;
@@ -141,7 +141,7 @@ static struct bt_event_class *create_simple_event(const char *name)
 		goto error;
 	}
 
-	ret = bt_event_class_set_payload_type(event, payload);
+	ret = bt_private_event_class_set_payload_type(event, payload);
 	if (ret) {
 		diag("Failed to set simple event payload");
 		goto error;
@@ -164,14 +164,14 @@ error:
  *           - uint16_t payload_16;
  *           - uint32_t payload_32;
  */
-static struct bt_event_class *create_complex_event(const char *name)
+static struct bt_private_event_class *create_complex_event(const char *name)
 {
 	int ret;
-	struct bt_event_class *event = NULL;
+	struct bt_private_event_class *event = NULL;
 	struct bt_field_type *inner = NULL, *outer = NULL;
 
 	assert(name);
-	event = bt_event_class_create(name);
+	event = bt_private_event_class_create(name);
 	if (!event) {
 		diag("Failed to create complex event");
 		goto error;
@@ -196,7 +196,7 @@ static struct bt_event_class *create_complex_event(const char *name)
 		goto error;
 	}
 
-	ret = bt_event_class_set_payload_type(event, outer);
+	ret = bt_private_event_class_set_payload_type(event, outer);
 	if (ret) {
 		diag("Failed to set complex event payload");
 		goto error;
@@ -211,7 +211,7 @@ error:
 }
 
 static void set_stream_class_field_types(
-		struct bt_stream_class *stream_class)
+		struct bt_private_stream_class *stream_class)
 {
 	struct bt_field_type *packet_context_type;
 	struct bt_field_type *event_header_type;
@@ -242,10 +242,10 @@ static void set_stream_class_field_types(
 	assert(ret == 0);
 	bt_put(ft);
 
-	ret = bt_stream_class_set_packet_context_type(stream_class,
+	ret = bt_private_stream_class_set_packet_context_type(stream_class,
 		packet_context_type);
 	assert(ret == 0);
-	ret = bt_stream_class_set_event_header_type(stream_class,
+	ret = bt_private_stream_class_set_event_header_type(stream_class,
 		event_header_type);
 	assert(ret == 0);
 
@@ -253,13 +253,13 @@ static void set_stream_class_field_types(
 	bt_put(event_header_type);
 }
 
-static struct bt_stream_class *create_sc1(void)
+static struct bt_private_stream_class *create_sc1(void)
 {
 	int ret;
-	struct bt_event_class *ec1 = NULL, *ec2 = NULL;
-	struct bt_stream_class *sc1 = NULL, *ret_stream = NULL;
+	struct bt_private_event_class *ec1 = NULL, *ec2 = NULL;
+	struct bt_private_stream_class *sc1 = NULL, *ret_stream = NULL;
 
-	sc1 = bt_stream_class_create_empty("sc1");
+	sc1 = bt_private_stream_class_create_empty("sc1");
 	if (!sc1) {
 		diag("Failed to create Stream Class");
 		goto error;
@@ -271,7 +271,7 @@ static struct bt_stream_class *create_sc1(void)
 		diag("Failed to create complex event EC1");
 		goto error;
 	}
-	ret = bt_stream_class_add_event_class(sc1, ec1);
+	ret = bt_private_stream_class_add_private_event_class(sc1, ec1);
 	if (ret) {
 		diag("Failed to add EC1 to SC1");
 		goto error;
@@ -282,17 +282,17 @@ static struct bt_stream_class *create_sc1(void)
 		diag("Failed to create simple event EC2");
 		goto error;
 	}
-	ret = bt_stream_class_add_event_class(sc1, ec2);
+	ret = bt_private_stream_class_add_private_event_class(sc1, ec2);
 	if (ret) {
 		diag("Failed to add EC1 to SC1");
 		goto error;
 	}
 
-	ret_stream = bt_event_class_get_stream_class(ec1);
+	ret_stream = bt_private_event_class_get_private_stream_class(ec1);
 	ok(ret_stream == sc1, "Get parent stream SC1 from EC1");
 	BT_PUT(ret_stream);
 
-	ret_stream = bt_event_class_get_stream_class(ec2);
+	ret_stream = bt_private_event_class_get_private_stream_class(ec2);
 	ok(ret_stream == sc1, "Get parent stream SC1 from EC2");
 end:
 	BT_PUT(ret_stream);
@@ -304,13 +304,13 @@ error:
 	goto end;
 }
 
-static struct bt_stream_class *create_sc2(void)
+static struct bt_private_stream_class *create_sc2(void)
 {
 	int ret;
-	struct bt_event_class *ec3 = NULL;
-	struct bt_stream_class *sc2 = NULL, *ret_stream = NULL;
+	struct bt_private_event_class *ec3 = NULL;
+	struct bt_private_stream_class *sc2 = NULL, *ret_stream = NULL;
 
-	sc2 = bt_stream_class_create_empty("sc2");
+	sc2 = bt_private_stream_class_create_empty("sc2");
 	if (!sc2) {
 		diag("Failed to create Stream Class");
 		goto error;
@@ -322,13 +322,13 @@ static struct bt_stream_class *create_sc2(void)
 		diag("Failed to create simple event EC3");
 		goto error;
 	}
-	ret = bt_stream_class_add_event_class(sc2, ec3);
+	ret = bt_private_stream_class_add_private_event_class(sc2, ec3);
 	if (ret) {
 		diag("Failed to add EC3 to SC2");
 		goto error;
 	}
 
-	ret_stream = bt_event_class_get_stream_class(ec3);
+	ret_stream = bt_private_event_class_get_private_stream_class(ec3);
 	ok(ret_stream == sc2, "Get parent stream SC2 from EC3");
 end:
 	BT_PUT(ret_stream);
@@ -339,7 +339,7 @@ error:
 	goto end;
 }
 
-static void set_trace_packet_header(struct bt_trace *trace)
+static void set_trace_packet_header(struct bt_private_trace *trace)
 {
 	struct bt_field_type *packet_header_type;
 	struct bt_field_type *ft;
@@ -354,22 +354,22 @@ static void set_trace_packet_header(struct bt_trace *trace)
 	assert(ret == 0);
 	bt_put(ft);
 
-	ret = bt_trace_set_packet_header_type(trace,
+	ret = bt_private_trace_set_packet_header_type(trace,
 		packet_header_type);
 	assert(ret == 0);
 
 	bt_put(packet_header_type);
 }
 
-static struct bt_trace *create_tc1(void)
+static struct bt_private_trace *create_tc1(void)
 {
 	int ret;
-	struct bt_trace *tc1 = NULL;
-	struct bt_stream_class *sc1 = NULL, *sc2 = NULL;
+	struct bt_private_trace *tc1 = NULL;
+	struct bt_private_stream_class *sc1 = NULL, *sc2 = NULL;
 
-	tc1 = bt_trace_create();
+	tc1 = bt_private_trace_create();
 	if (!tc1) {
-		diag("bt_trace_create returned NULL");
+		diag("bt_private_trace_create returned NULL");
 		goto error;
 	}
 
@@ -379,7 +379,7 @@ static struct bt_trace *create_tc1(void)
 	if (!sc1) {
 		goto error;
 	}
-	ret = bt_trace_add_stream_class(tc1, sc1);
+	ret = bt_private_trace_add_private_stream_class(tc1, sc1);
 	ok(!ret, "Add SC1 to TC1");
 	if (ret) {
 		goto error;
@@ -390,7 +390,7 @@ static struct bt_trace *create_tc1(void)
 	if (!sc2) {
 		goto error;
 	}
-	ret = bt_trace_add_stream_class(tc1, sc2);
+	ret = bt_private_trace_add_private_stream_class(tc1, sc2);
 	ok(!ret, "Add SC2 to TC1");
 	if (ret) {
 		goto error;
@@ -404,20 +404,20 @@ error:
 	goto end;
 }
 
-static void init_weak_refs(struct bt_trace *tc,
-		struct bt_trace **tc1,
-		struct bt_stream_class **sc1,
-		struct bt_stream_class **sc2,
-		struct bt_event_class **ec1,
-		struct bt_event_class **ec2,
-		struct bt_event_class **ec3)
+static void init_weak_refs(struct bt_private_trace *tc,
+		struct bt_private_trace **tc1,
+		struct bt_private_stream_class **sc1,
+		struct bt_private_stream_class **sc2,
+		struct bt_private_event_class **ec1,
+		struct bt_private_event_class **ec2,
+		struct bt_private_event_class **ec3)
 {
 	*tc1 = tc;
-	*sc1 = bt_trace_get_stream_class_by_index(tc, 0);
-	*sc2 = bt_trace_get_stream_class_by_index(tc, 1);
-	*ec1 = bt_stream_class_get_event_class_by_index(*sc1, 0);
-	*ec2 = bt_stream_class_get_event_class_by_index(*sc1, 1);
-	*ec3 = bt_stream_class_get_event_class_by_index(*sc2, 0);
+	*sc1 = bt_private_trace_get_private_stream_class_by_index(tc, 0);
+	*sc2 = bt_private_trace_get_private_stream_class_by_index(tc, 1);
+	*ec1 = bt_private_stream_class_get_private_event_class_by_index(*sc1, 0);
+	*ec2 = bt_private_stream_class_get_private_event_class_by_index(*sc1, 1);
+	*ec3 = bt_private_stream_class_get_private_event_class_by_index(*sc2, 0);
 	bt_put(*sc1);
 	bt_put(*sc2);
 	bt_put(*ec1);
@@ -434,9 +434,9 @@ static void test_example_scenario(void)
 	 * counts without affecting them by taking "real" references to the
 	 * objects.
 	 */
-	struct bt_trace *tc1 = NULL, *weak_tc1 = NULL;
-	struct bt_stream_class *weak_sc1 = NULL, *weak_sc2 = NULL;
-	struct bt_event_class *weak_ec1 = NULL, *weak_ec2 = NULL,
+	struct bt_private_trace *tc1 = NULL, *weak_tc1 = NULL;
+	struct bt_private_stream_class *weak_sc1 = NULL, *weak_sc2 = NULL;
+	struct bt_private_event_class *weak_ec1 = NULL, *weak_ec2 = NULL,
 			*weak_ec3 = NULL;
 	struct user user_a = { 0 }, user_b = { 0 }, user_c = { 0 };
 
@@ -467,7 +467,7 @@ static void test_example_scenario(void)
 			"TC1 reference count is 1");
 
 	/* User A acquires a reference to SC2 from TC1. */
-	user_a.sc = bt_trace_get_stream_class_by_index(user_a.tc, 1);
+	user_a.sc = bt_private_trace_get_private_stream_class_by_index(user_a.tc, 1);
 	ok(user_a.sc, "User A acquires SC2 from TC1");
 	ok(bt_object_get_ref_count(weak_tc1) == 2,
 			"TC1 reference count is 2");
@@ -475,7 +475,7 @@ static void test_example_scenario(void)
 			"SC2 reference count is 1");
 
 	/* User A acquires a reference to EC3 from SC2. */
-	user_a.ec = bt_stream_class_get_event_class_by_index(user_a.sc, 0);
+	user_a.ec = bt_private_stream_class_get_private_event_class_by_index(user_a.sc, 0);
 	ok(user_a.ec, "User A acquires EC3 from SC2");
 	ok(bt_object_get_ref_count(weak_tc1) == 2,
 			"TC1 reference count is 2");
@@ -522,7 +522,7 @@ static void test_example_scenario(void)
 
 	/* User C acquires a reference to EC1. */
 	diag("User C acquires a reference to EC1");
-	user_c.ec = bt_stream_class_get_event_class_by_index(user_b.sc, 0);
+	user_c.ec = bt_private_stream_class_get_private_event_class_by_index(user_b.sc, 0);
 	ok(bt_object_get_ref_count(weak_ec1) == 1,
 			"EC1 reference count is 1");
 	ok(bt_object_get_ref_count(weak_sc1) == 2,
@@ -571,6 +571,7 @@ static void create_user_full(struct user *user)
 	struct bt_field_type *ft;
 	struct bt_field *field;
 	struct bt_ctf_clock *clock;
+	struct bt_event *pub_event;
 	int ret;
 
 	trace_path = g_build_filename(g_get_tmp_dir(), "ctfwriter_XXXXXX", NULL);
@@ -585,44 +586,47 @@ static void create_user_full(struct user *user)
 	assert(ret == 0);
 	user->tc = bt_ctf_writer_get_trace(user->writer);
 	assert(user->tc);
-	user->sc = bt_stream_class_create("sc");
+	user->sc = bt_private_stream_class_create("sc");
 	assert(user->sc);
 	clock = bt_ctf_clock_create("the_clock");
 	assert(clock);
 	ret = bt_ctf_writer_add_clock(user->writer, clock);
 	assert(!ret);
-	ret = bt_stream_class_set_clock(user->sc, clock);
+	ret = bt_private_stream_class_set_clock(user->sc, clock);
 	assert(!ret);
 	BT_PUT(clock);
 	user->stream = bt_ctf_writer_create_stream(user->writer, user->sc);
 	assert(user->stream);
-	user->ec = bt_event_class_create("ec");
+	user->ec = bt_private_event_class_create("ec");
 	assert(user->ec);
 	ft = create_integer_struct();
 	assert(ft);
-	ret = bt_event_class_set_payload_type(user->ec, ft);
+	ret = bt_private_event_class_set_payload_type(user->ec, ft);
 	BT_PUT(ft);
 	assert(!ret);
-	ret = bt_stream_class_add_event_class(user->sc, user->ec);
+	ret = bt_private_stream_class_add_private_event_class(user->sc, user->ec);
 	assert(!ret);
-	user->event = bt_event_create(user->ec);
+	user->event = bt_private_event_create(user->ec);
 	assert(user->event);
-	field = bt_event_get_payload(user->event, "payload_8");
+	pub_event = bt_event_from_private(user->event);
+	field = bt_event_get_payload(pub_event, "payload_8");
 	assert(field);
 	ret = bt_field_unsigned_integer_set_value(field, 10);
 	assert(!ret);
 	BT_PUT(field);
-	field = bt_event_get_payload(user->event, "payload_16");
+	field = bt_event_get_payload(pub_event, "payload_16");
 	assert(field);
 	ret = bt_field_unsigned_integer_set_value(field, 20);
 	assert(!ret);
 	BT_PUT(field);
-	field = bt_event_get_payload(user->event, "payload_32");
+	field = bt_event_get_payload(pub_event, "payload_32");
 	assert(field);
 	ret = bt_field_unsigned_integer_set_value(field, 30);
 	assert(!ret);
 	BT_PUT(field);
-	ret = bt_stream_append_event(user->stream, user->event);
+	BT_PUT(pub_event);
+	ret = bt_private_stream_append_private_event(user->stream,
+		user->event);
 	assert(!ret);
 	recursive_rmdir(trace_path);
 	g_free(trace_path);

--- a/tests/plugins/test-utils-muxer.c
+++ b/tests/plugins/test-utils-muxer.c
@@ -75,12 +75,12 @@ static GArray *test_events;
 static struct bt_clock_class_priority_map *src_cc_prio_map;
 static struct bt_clock_class_priority_map *src_empty_cc_prio_map;
 static struct bt_clock_class *src_clock_class;
-static struct bt_stream_class *src_stream_class;
-static struct bt_event_class *src_event_class;
-static struct bt_packet *src_packet0;
-static struct bt_packet *src_packet1;
-static struct bt_packet *src_packet2;
-static struct bt_packet *src_packet3;
+static struct bt_private_stream_class *src_stream_class;
+static struct bt_private_event_class *src_event_class;
+static struct bt_private_packet *src_packet0;
+static struct bt_private_packet *src_packet1;
+static struct bt_private_packet *src_packet2;
+static struct bt_private_packet *src_packet3;
 
 enum {
 	SEQ_END = -1,
@@ -93,7 +93,7 @@ struct src_iter_user_data {
 	size_t iter_index;
 	int64_t *seq;
 	size_t at;
-	struct bt_packet *packet;
+	struct bt_private_packet *packet;
 };
 
 struct sink_user_data {
@@ -287,8 +287,8 @@ static
 void init_static_data(void)
 {
 	int ret;
-	struct bt_trace *trace;
-	struct bt_stream *stream;
+	struct bt_private_trace *trace;
+	struct bt_private_stream *stream;
 	struct bt_field_type *empty_struct_ft;
 
 	/* Test events */
@@ -298,18 +298,18 @@ void init_static_data(void)
 	/* Metadata */
 	empty_struct_ft = bt_field_type_structure_create();
 	assert(empty_struct_ft);
-	trace = bt_trace_create();
+	trace = bt_private_trace_create();
 	assert(trace);
-	ret = bt_trace_set_native_byte_order(trace,
+	ret = bt_private_trace_set_native_byte_order(trace,
 		BT_BYTE_ORDER_LITTLE_ENDIAN);
 	assert(ret == 0);
-	ret = bt_trace_set_packet_header_type(trace, empty_struct_ft);
+	ret = bt_private_trace_set_packet_header_type(trace, empty_struct_ft);
 	assert(ret == 0);
 	src_clock_class = bt_clock_class_create("my-clock", 1000000000);
 	assert(src_clock_class);
 	ret = bt_clock_class_set_is_absolute(src_clock_class, 1);
 	assert(ret == 0);
-	ret = bt_trace_add_clock_class(trace, src_clock_class);
+	ret = bt_private_trace_add_clock_class(trace, src_clock_class);
 	assert(ret == 0);
 	src_empty_cc_prio_map = bt_clock_class_priority_map_create();
 	assert(src_empty_cc_prio_map);
@@ -318,47 +318,47 @@ void init_static_data(void)
 	ret = bt_clock_class_priority_map_add_clock_class(src_cc_prio_map,
 		src_clock_class, 0);
 	assert(ret == 0);
-	src_stream_class = bt_stream_class_create("my-stream-class");
+	src_stream_class = bt_private_stream_class_create("my-stream-class");
 	assert(src_stream_class);
-	ret = bt_stream_class_set_packet_context_type(src_stream_class,
+	ret = bt_private_stream_class_set_packet_context_type(src_stream_class,
 		empty_struct_ft);
 	assert(ret == 0);
-	ret = bt_stream_class_set_event_header_type(src_stream_class,
+	ret = bt_private_stream_class_set_event_header_type(src_stream_class,
 		empty_struct_ft);
 	assert(ret == 0);
-	ret = bt_stream_class_set_event_context_type(src_stream_class,
+	ret = bt_private_stream_class_set_event_context_type(src_stream_class,
 		empty_struct_ft);
 	assert(ret == 0);
-	src_event_class = bt_event_class_create("my-event-class");
-	ret = bt_event_class_set_context_type(src_event_class,
+	src_event_class = bt_private_event_class_create("my-event-class");
+	ret = bt_private_event_class_set_context_type(src_event_class,
 		empty_struct_ft);
 	assert(ret == 0);
-	ret = bt_event_class_set_context_type(src_event_class,
+	ret = bt_private_event_class_set_context_type(src_event_class,
 		empty_struct_ft);
 	assert(ret == 0);
-	ret = bt_stream_class_add_event_class(src_stream_class,
+	ret = bt_private_stream_class_add_private_event_class(src_stream_class,
 		src_event_class);
 	assert(ret == 0);
-	ret = bt_trace_add_stream_class(trace, src_stream_class);
+	ret = bt_private_trace_add_private_stream_class(trace, src_stream_class);
 	assert(ret == 0);
-	stream = bt_stream_create(src_stream_class, "stream0");
+	stream = bt_private_stream_create(src_stream_class, "stream0");
 	assert(stream);
-	src_packet0 = bt_packet_create(stream);
+	src_packet0 = bt_private_packet_create(stream);
 	assert(src_packet0);
 	bt_put(stream);
-	stream = bt_stream_create(src_stream_class, "stream1");
+	stream = bt_private_stream_create(src_stream_class, "stream1");
 	assert(stream);
-	src_packet1 = bt_packet_create(stream);
+	src_packet1 = bt_private_packet_create(stream);
 	assert(src_packet0);
 	bt_put(stream);
-	stream = bt_stream_create(src_stream_class, "stream2");
+	stream = bt_private_stream_create(src_stream_class, "stream2");
 	assert(stream);
-	src_packet2 = bt_packet_create(stream);
+	src_packet2 = bt_private_packet_create(stream);
 	assert(src_packet0);
 	bt_put(stream);
-	stream = bt_stream_create(src_stream_class, "stream3");
+	stream = bt_private_stream_create(src_stream_class, "stream3");
 	assert(stream);
-	src_packet3 = bt_packet_create(stream);
+	src_packet3 = bt_private_packet_create(stream);
 	assert(src_packet0);
 	bt_put(stream);
 
@@ -481,14 +481,14 @@ enum bt_notification_iterator_status src_iter_init(
 }
 
 static
-struct bt_event *src_create_event(struct bt_packet *packet,
+struct bt_private_event *src_create_event(struct bt_private_packet *packet,
 		int64_t ts_ns)
 {
-	struct bt_event *event = bt_event_create(src_event_class);
+	struct bt_private_event *event = bt_private_event_create(src_event_class);
 	int ret;
 
 	assert(event);
-	ret = bt_event_set_packet(event, packet);
+	ret = bt_private_event_set_private_packet(event, packet);
 	assert(ret == 0);
 
 	if (ts_ns != -1) {
@@ -497,7 +497,7 @@ struct bt_event *src_create_event(struct bt_packet *packet,
 		clock_value = bt_clock_value_create(src_clock_class,
 			(uint64_t) ts_ns);
 		assert(clock_value);
-		ret = bt_event_set_clock_value(event, clock_value);
+		ret = bt_private_event_set_clock_value(event, clock_value);
 		assert(ret == 0);
 		bt_put(clock_value);
 	}
@@ -528,22 +528,27 @@ struct bt_notification_iterator_next_method_return src_iter_next_seq(
 		break;
 	case SEQ_PACKET_BEGIN:
 		next_return.notification =
-			bt_notification_packet_begin_create(user_data->packet);
+			bt_notification_borrow_from_private(
+				bt_private_notification_packet_begin_create(
+					user_data->packet));
 		assert(next_return.notification);
 		break;
 	case SEQ_PACKET_END:
 		next_return.notification =
-			bt_notification_packet_end_create(user_data->packet);
+			bt_notification_borrow_from_private(
+				bt_private_notification_packet_end_create(
+					user_data->packet));
 		assert(next_return.notification);
 		break;
 	default:
 	{
-		struct bt_event *event = src_create_event(
+		struct bt_private_event *event = src_create_event(
 			user_data->packet, cur_ts_ns);
 
 		assert(event);
-		next_return.notification = bt_notification_event_create(event,
-			src_cc_prio_map);
+		next_return.notification = bt_notification_borrow_from_private(
+			bt_private_notification_event_create(event,
+				src_cc_prio_map));
 		bt_put(event);
 		assert(next_return.notification);
 		break;
@@ -579,17 +584,19 @@ struct bt_notification_iterator_next_method_return src_iter_next(
 		if (user_data->iter_index == 0) {
 			if (user_data->at == 0) {
 				next_return.notification =
-					bt_notification_packet_begin_create(
-						user_data->packet);
+					bt_notification_borrow_from_private(
+					bt_private_notification_packet_begin_create(
+						user_data->packet));
 				assert(next_return.notification);
 			} else if (user_data->at < 6) {
-				struct bt_event *event = src_create_event(
+				struct bt_private_event *event = src_create_event(
 					user_data->packet, -1);
 
 				assert(event);
 				next_return.notification =
-					bt_notification_event_create(event,
-						src_empty_cc_prio_map);
+					bt_notification_borrow_from_private(
+					bt_private_notification_event_create(event,
+						src_empty_cc_prio_map));
 				assert(next_return.notification);
 				bt_put(event);
 			} else {


### PR DESCRIPTION
This is a partial patch which splits the CTF IR and notification APIs into public and private parts.

What is missing is:

* API documentation (new and updates)
* Python bindings and their tests
* `plugins/ctf/fs-sink`
* `plugins/libctfcopytrace`
* `plugins/lttng-utils`
* `plugins/utils/trimmer` which must be updated to copy packets/events instead of hijacking the upstream notifications

If you like the approach, I'll continue the work.

With this patch, it's not possible for a downstream component to modify any upstream object, for example for a filter to add a stream class to a source's trace, without getting a compiler warning (incompatible pointers). An upstream component creates private objects (metadata, notifications), and downstream components have access to the public views only.

This mechanism based on C's (sort of) strong typing is orthogonal to BT's existing freezing concept, the latter making it impossible for an upstream component to modify an object once it's part of an emitted notification so that downstream components are guaranteed to have immutable public objects.

Question: should we create individual `private-X.h` header files for the private APIs? We did this with private connections, private ports, private components, etc.

I created the `bt_notification_borrow_from_private()` function to get the public view of a private notification without incrementing its reference count. This is useful at various places because the pattern is often (in a "next" method):

    struct bt_notification_iterator_next_method_return next_return = {
        .notification = NULL,
        .status = BT_NOTIFICATION_ITERATOR_STATUS_OK,
    };

    next_return.notification = bt_notification_borrow_from_private(
        bt_private_notification_SOMETHING_create(...));

    // ...

    return next_return;

This borrowing could prove useful for CTF IR objects too. Should I add such borrowing functions for all private CTF IR objects (and perhaps for private graph objects too)? They are internal for the moment.