### PR TITLE
[RFC] Implementation of fields __str__ method

### DIFF
--- a/bindings/python/bt2/bt2/fields.py
+++ b/bindings/python/bt2/bt2/fields.py
@@ -629,6 +629,9 @@ class _ArraySequenceField(_ContainerField, collections.abc.MutableSequence):
     def _value(self):
         return [field._value for field in self]
 
+    def __repr__(self):
+        return '[{}]'.format(', '.join([repr(v) for v in self]))
+
 
 class _ArrayField(_ArraySequenceField):
     _NAME = 'Array'

--- a/bindings/python/bt2/bt2/fields.py
+++ b/bindings/python/bt2/bt2/fields.py
@@ -426,6 +426,9 @@ class _StringField(_Field, collections.abc.Sequence):
     def __bool__(self):
         return bool(self._value)
 
+    def __repr__(self):
+        return repr(self._value)
+
     def __str__(self):
         return self._value
 

--- a/bindings/python/bt2/bt2/fields.py
+++ b/bindings/python/bt2/bt2/fields.py
@@ -366,6 +366,10 @@ class _EnumerationField(_IntegerField):
     def _set_value(self, value):
         self.integer_field.value = value
 
+    def __repr__(self):
+        labels = [repr(v.name) for v in self.mappings]
+        return '{} ({})'.format(self._value, ', '.join(labels))
+
     value = property(fset=_set_value)
 
     @property

--- a/bindings/python/bt2/bt2/fields.py
+++ b/bindings/python/bt2/bt2/fields.py
@@ -110,8 +110,8 @@ class _NumericField(_Field):
     def __float__(self):
         return float(self._value)
 
-    def __str__(self):
-        return str(self._value)
+    def __repr__(self):
+        return repr(self._value)
 
     def __lt__(self, other):
         if not isinstance(other, numbers.Number):

--- a/bindings/python/bt2/bt2/fields.py
+++ b/bindings/python/bt2/bt2/fields.py
@@ -526,6 +526,10 @@ class _StructureField(_ContainerField, collections.abc.MutableMapping):
 
     value = property(fset=_set_value)
 
+    def __repr__(self):
+        items = ['{}: {}'.format(repr(k), repr(v)) for k, v in self.items()]
+        return '{{{}}}'.format(', '.join(items))
+
 
 class _VariantField(_Field):
     _NAME = 'Variant'

--- a/bindings/python/bt2/bt2/fields.py
+++ b/bindings/python/bt2/bt2/fields.py
@@ -566,6 +566,9 @@ class _VariantField(_Field):
     def __bool__(self):
         return bool(self.selected_field)
 
+    def __repr__(self):
+        return repr(self._value)
+
     @property
     def _value(self):
         if self.selected_field is not None:


### PR DESCRIPTION
We never implemented the `__str__` methods for the various fields in the bt2 bindings.
I'm unsure about the best layout to use when printing those fields, especially `_VariantField` and `_EnumerationField`.

What I'm proposing here looked good in my [PyCon demo](https://github.com/jgalar/PyConCanada2017), but there may be conventions I'm not aware of as far as `__str__` is concerned.

Sample output:
```
epoll_ctl(epfd = 60, op_enum = EPOLL_CTL_ADD(1), fd = 45, event = {'data_union': {'u64': 45, 'fd': 45}, 'raw_events': 24, 'events': {'EPOLLIN': 0, 'EPOLLPRI': 0, 'EPOLLOUT': 0, 'EPOLLERR': 1, 'padding': 1}})
```

Note the `op_enum` (an enumeration) and `event` (a structure) fields.

```
ppoll(tsp = 139894578764976, sigmask = 0, sigsetsize = 8, nfds = 4, fds_length = 4, overflow = 0, fds = [{'fd': 26, 'raw_events': 1, 'events': {'POLLIN': 1, 'POLLPRI': 0, 'POLLOUT': 0, 'POLLERR': 0, 'POLLHUP': 0, 'padding': 0}}, {'fd': 31, 'raw_events': 41, 'events': {'POLLIN': 1, 'POLLPRI': 0, 'POLLOUT': 0, 'POLLERR': 1, 'POLLHUP': 0, 'padding': 1}}, {'fd': 27, 'raw_events': 1, 'events': {'POLLIN': 1, 'POLLPRI': 0, 'POLLOUT': 0, 'POLLERR': 0, 'POLLHUP': 0, 'padding': 0}}, {'fd': 67, 'raw_events': 44, 'events': {'POLLIN': 0, 'POLLPRI': 0, 'POLLOUT': 1, 'POLLERR': 1, 'POLLHUP': 0, 'padding': 1}}])
```

Note the `fds` field (a sequence of structures).