### PR TITLE
Python: Implementation of __repr__ instead of __str__ for Values and Fields

### DIFF
--- a/bindings/python/bt2/bt2/fields.py
+++ b/bindings/python/bt2/bt2/fields.py
@@ -111,6 +111,9 @@ class _NumericField(_Field):
         return float(self._value)
 
     def __repr__(self):
+        if not self.is_set:
+            return 'Unset'
+
         return repr(self._value)
 
     def __lt__(self, other):
@@ -367,6 +370,9 @@ class _EnumerationField(_IntegerField):
         self.integer_field.value = value
 
     def __repr__(self):
+        if not self.is_set:
+            return 'Unset'
+
         labels = [repr(v.name) for v in self.mappings]
         return '{} ({})'.format(self._value, ', '.join(labels))
 
@@ -427,6 +433,9 @@ class _StringField(_Field, collections.abc.Sequence):
         return bool(self._value)
 
     def __repr__(self):
+        if not self.is_set:
+            return 'Unset'
+
         return repr(self._value)
 
     def __str__(self):
@@ -530,6 +539,9 @@ class _StructureField(_ContainerField, collections.abc.MutableMapping):
     value = property(fset=_set_value)
 
     def __repr__(self):
+        if not self.is_set:
+            return 'Unset'
+
         items = ['{}: {}'.format(repr(k), repr(v)) for k, v in self.items()]
         return '{{{}}}'.format(', '.join(items))
 
@@ -570,6 +582,9 @@ class _VariantField(_Field):
         return bool(self.selected_field)
 
     def __repr__(self):
+        if not self.is_set:
+            return 'Unset'
+
         return repr(self._value)
 
     @property
@@ -633,6 +648,9 @@ class _ArraySequenceField(_ContainerField, collections.abc.MutableSequence):
         return [field._value for field in self]
 
     def __repr__(self):
+        if not self.is_set:
+            return 'Unset'
+
         return '[{}]'.format(', '.join([repr(v) for v in self]))
 
 

--- a/bindings/python/bt2/bt2/values.py
+++ b/bindings/python/bt2/bt2/values.py
@@ -166,8 +166,8 @@ class _NumericValue(_Value, _BasicCopy):
     def __float__(self):
         return float(self._value)
 
-    def __str__(self):
-        return str(self._value)
+    def __repr__(self):
+        return repr(self._value)
 
     def __lt__(self, other):
         if not isinstance(other, numbers.Number):
@@ -359,8 +359,8 @@ class BoolValue(_Value, _BasicCopy):
     def __bool__(self):
         return self._value
 
-    def __str__(self):
-        return str(self._value)
+    def __repr__(self):
+        return repr(self._value)
 
     def _value_to_bool(self, value):
         if isinstance(value, BoolValue):
@@ -497,6 +497,9 @@ class StringValue(_BasicCopy, collections.abc.Sequence, _Value):
     def __bool__(self):
         return bool(self._value)
 
+    def __repr__(self):
+        repr(self._value)
+
     def __str__(self):
         return self._value
 
@@ -614,16 +617,8 @@ class ArrayValue(_Container, collections.abc.MutableSequence, _Value):
 
         return self
 
-    def __str__(self):
-        strings = []
-
-        for elem in self:
-            if isinstance(elem, StringValue):
-                strings.append(repr(elem._value))
-            else:
-                strings.append(str(elem))
-
-        return '[{}]'.format(', '.join(strings))
+    def __repr__(self):
+        return '[{}]'.format(', '.join([repr(v) for v in self]))
 
     def insert(self, value):
         raise NotImplementedError
@@ -726,18 +721,9 @@ class MapValue(_Container, collections.abc.MutableMapping, _Value):
         status = native_bt.value_map_insert(self._ptr, key, ptr)
         self._handle_status(status)
 
-    def __str__(self):
-        strings = []
-
-        for key, elem in self.items():
-            if isinstance(elem, StringValue):
-                value = repr(elem._value)
-            else:
-                value = str(elem)
-
-            strings.append('{}: {}'.format(repr(key), value))
-
-        return '{{{}}}'.format(', '.join(strings))
+    def __repr__(self):
+        items = ['{}: {}'.format(repr(k), repr(v)) for k, v in self.items()]
+        return '{{{}}}'.format(', '.join(items))
 
 
 _TYPE_TO_OBJ = {


### PR DESCRIPTION
These two commits are only related in that they both address the implementation of the `__repr__` methods in both the Value and Field APIs of the `bt2` python package.

The first commit adds an "Unset" return to all __repr__ implementations of Fields when they are not `set`. This seemed okay after discussion with @eepp, but I'm wondering if there is a canonical representation of an unset object recommended by Python...

We don't want to use `None` as CTF 2 will most likely introduce a `Null` object for which we reserve the semantics of returning `None`.

In the case of Value, I applied the same modifications as were done in Field last week.

These modifications still need tests.