### PR TITLE
Fix: to enable access to sequence_text field type data from API.

### DIFF
--- a/include/babeltrace/types.h
+++ b/include/babeltrace/types.h
@@ -448,6 +448,7 @@ struct declaration_enum *
 struct declaration_string *
 	bt_string_declaration_new(enum ctf_string_encoding encoding);
 char *bt_get_string(const struct bt_definition *field);
+char *bt_get_sequence_text(const struct bt_definition *field);
 enum ctf_string_encoding bt_get_string_encoding(const struct bt_definition *field);
 
 double bt_get_float(const struct bt_definition *field);

--- a/types/string.c
+++ b/types/string.c
@@ -129,3 +129,13 @@ char *bt_get_string(const struct bt_definition *field)
 
 	return string_definition->value;
 }
+
+char *bt_get_sequence_text(const struct bt_definition *field)
+{
+	struct definition_sequence *sequence_definition =
+		container_of(field, struct definition_sequence, p);
+
+	assert(sequence_definition->string != NULL);
+
+	return sequence_definition->string->str;
+}


### PR DESCRIPTION
Currently reading from _sequence_text_ field type is not exposed by the API (at least I couldn't find any possible way of doing this).
_sequence_definition->string_ is properly allocated and populated when sequence_text is read from trace events.
However, _bt_ctf_get_string_ does not consider _SEQUENCE_TYPE_ and does not return the string in such type of field.