### PR TITLE
Fix: do not resolve debug info on build id mismatch

### DIFF
--- a/include/babeltrace/bin-info.h
+++ b/include/babeltrace/bin-info.h
@@ -62,6 +62,8 @@ struct bin_info {
 	int dwarf_fd;
 	/* Denotes whether the executable is position independent code. */
 	bool is_pic:1;
+	/* Denotes whether the build id in the trace matches to one on disk. */
+	bool file_build_id_matches:1;
 	/*
 	 * Denotes whether the executable only has ELF symbols and no
 	 * DWARF info.

--- a/tests/lib/test_bin_info.c
+++ b/tests/lib/test_bin_info.c
@@ -26,7 +26,7 @@
 #include <babeltrace/bin-info.h>
 #include "tap/tap.h"
 
-#define NR_TESTS 36
+#define NR_TESTS 38
 #define SO_NAME "libhello_so"
 #define SO_NAME_ELF "libhello_elf_so"
 #define SO_NAME_BUILD_ID "libhello_build_id_so"
@@ -95,6 +95,26 @@ void test_bin_info_build_id(const char *data_dir)
 	} else {
 		skip(2, "bin_info_lookup_source_location - src_loc is NULL");
 	}
+
+	bin_info_destroy(bin);
+}
+static
+void test_bin_info_mismatching_build_id(const char *data_dir)
+{
+	int ret;
+	char path[PATH_MAX];
+	struct bin_info *bin = NULL;
+	uint8_t build_id_wrong[BUILD_ID_LEN] = {
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99
+	};
+	diag("bin-info tests - mismatching build ID");
+	snprintf(path, PATH_MAX, "%s/%s", data_dir, SO_NAME_BUILD_ID);
+	bin = bin_info_create(path, SO_LOW_ADDR, SO_MEMSZ, true);
+	ok(bin != NULL, "bin_info_create successful");
+	/* Test setting mismatching build_id */
+	ret = bin_info_set_build_id(bin, build_id_wrong, BUILD_ID_LEN);
+	ok(ret != 0, "bin_info_set_build_id unsuccessful as expected");
 
 	bin_info_destroy(bin);
 }
@@ -289,6 +309,7 @@ int main(int argc, char **argv)
 	ok(ret == 0, "bin_info_init successful");
 
 	test_bin_info(opt_debug_info_dir);
+	test_bin_info_mismatching_build_id(opt_debug_info_dir);
 	test_bin_info_elf(opt_debug_info_dir);
 	test_bin_info_build_id(opt_debug_info_dir);
 	test_bin_info_debug_link(opt_debug_info_dir);


### PR DESCRIPTION

Issue
=====
Babeltrace is showing erroneous debugging information when a trace is
read on a system that has a different version of the binary that of the
binary recording in trace.

This is due to the fact that Babeltrace currently does not confirm that
the binary(or debuglink) before resolving the debugging information.

The build ids in the trace and in the local binary must be the same to
ensure that instruction pointer addresses can be decoded.

Solution
========
Now when setting the build id, confirm that the trace build id and the
binary build id match. Once the match is confirmed, set the
`file_build_id_matches` field in the corresponding the `bin_info`
structure. This way when decoding the events, we can quickly check if
the debugging information is available for that binary.

Drawback
========
None.