### PR TITLE
debug-info: Fix: not printing src field in for loops

### DIFF
--- a/include/babeltrace/dwarf.h
+++ b/include/babeltrace/dwarf.h
@@ -120,6 +120,15 @@ BT_HIDDEN
 void bt_dwarf_die_destroy(struct bt_dwarf_die *die);
 
 /**
+ * Indicates if the debug information entry `die` has children DIEs.
+ *
+ * @param die	bt_dwarf_die instance
+ * @returns	0 if the die no child, 1 otherwise
+ */
+BT_HIDDEN
+int bt_dwarf_die_has_children(struct bt_dwarf_die *die);
+
+/**
  * Advance the debug information entry `die` to its first child, if
  * any.
  *

--- a/lib/bin-info.c
+++ b/lib/bin-info.c
@@ -1024,21 +1024,36 @@ int bin_info_child_die_has_address(struct bt_dwarf_die *die, uint64_t addr, bool
 	}
 
 	do {
-		int tag;
-
-		ret = bt_dwarf_die_get_tag(die, &tag);
+		ret = bt_dwarf_die_contains_addr(die, addr, &_contains);
 		if (ret) {
 			goto error;
 		}
 
-		if (tag == DW_TAG_inlined_subroutine) {
-			ret = bt_dwarf_die_contains_addr(die, addr, &_contains);
+		if (_contains) {
+			/*
+			 * The address is within the range of the current DIE
+			 * or its children.
+			 */
+			int tag;
+
+			ret = bt_dwarf_die_get_tag(die, &tag);
 			if (ret) {
 				goto error;
 			}
 
-			if (_contains) {
+			if (tag == DW_TAG_inlined_subroutine) {
+				/* Found the tracepoint. */
 				goto end;
+			}
+
+			if (bt_dwarf_die_has_children(die)) {
+				/*
+				 * Look for the address in the children DIEs.
+				 */
+				ret = bt_dwarf_die_child(die);
+				if (ret) {
+					goto error;
+				}
 			}
 		}
 	} while (bt_dwarf_die_next(die) == 0);

--- a/lib/dwarf.c
+++ b/lib/dwarf.c
@@ -132,6 +132,12 @@ void bt_dwarf_die_destroy(struct bt_dwarf_die *die)
 }
 
 BT_HIDDEN
+int bt_dwarf_die_has_children(struct bt_dwarf_die *die)
+{
+	return dwarf_haschildren(die->dwarf_die);
+}
+
+BT_HIDDEN
 int bt_dwarf_die_child(struct bt_dwarf_die *die)
 {
 	int ret;


### PR DESCRIPTION
Issue
=====
When debugging information is available, Babeltrace does not print the
`src` field of a tracepoint properly when tracepoint is within a for
loop.

  #include "tp.h"
  int main(int argc, char *argv[])
  {
      tracepoint(my_app, empty);
      for(int i = 0; i < 1; i++) {
          tracepoint(my_app, empty);
      }
      return 0;
  }

The problem derives from the DWARF information generated by the
compiler. The compiler may place the DWARF content of the for loop in
`DW_TAG_lexical_block` which the current debug-info design doesn't
expect.

Here is a summarized version of DWARF tree containing the first
tracepoint in the code above:
  DW_TAG_subprogram
    DW_TAG_inlined_subroutine
      /* tracepoint callsite info */

Here is a summarized version of the DWARF tree containing the tracepoint
in the for loop:
  DW_TAG_subprogram
    DW_TAG_lexical_block
      DW_TAG_inlined_subroutine
        /* tracepoint callsite info */

The current implementation doesn't expect the presence of a
`DW_TAG_lexical_block` entry as child of the `DW_TAG_inlined_subroutine`
entry and won't look any further down that branch to find the source
information for the current tracepoint. This results in the Babeltrace
not finding the line number for such callsite and thus leaving the `src`
field empty.

Solution
========
When iterating over the Debugging Information Entries, if the current
entry contains the address to resolve _but_ is not a of the type
`DW_TAG_inlined_subroutine` try to iterate over the children of that
entry.

Known drawbacks
===============
None.

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>