### PR TITLE
export bt_ctf_field_type_{integer_get_base,string_get_encoding}

### DIFF
--- a/formats/ctf/ir/field-types.c
+++ b/formats/ctf/ir/field-types.c
@@ -742,7 +742,6 @@ end:
 	return ret;
 }
 
-BT_HIDDEN
 enum bt_ctf_integer_base bt_ctf_field_type_integer_get_base(
 		struct bt_ctf_field_type *type)
 {

--- a/formats/ctf/ir/field-types.c
+++ b/formats/ctf/ir/field-types.c
@@ -787,7 +787,6 @@ end:
 	return ret;
 }
 
-BT_HIDDEN
 enum bt_ctf_string_encoding bt_ctf_field_type_integer_get_encoding(
 		struct bt_ctf_field_type *type)
 {

--- a/include/babeltrace/ctf-ir/field-types-internal.h
+++ b/include/babeltrace/ctf-ir/field-types-internal.h
@@ -608,20 +608,6 @@ const char *bt_ctf_field_type_sequence_get_length_field_name(
 		struct bt_ctf_field_type *sequence);
 
 /*
- * bt_ctf_field_type_string_get_encoding: get a string type's encoding.
- *
- * Get the string type's encoding.
- *
- * @param string_type String type.
- *
- * Returns the string's encoding on success, a BT_CTF_STRING_ENCODING_UNKNOWN
- * on error.
- */
-BT_HIDDEN
-enum bt_ctf_string_encoding bt_ctf_field_type_string_get_encoding(
-		struct bt_ctf_field_type *string_type);
-
-/*
  * bt_ctf_field_type_get_alignment: get a field type's alignment.
  *
  * Get the field type's alignment.

--- a/include/babeltrace/ctf-ir/field-types-internal.h
+++ b/include/babeltrace/ctf-ir/field-types-internal.h
@@ -272,20 +272,6 @@ BT_HIDDEN
 int bt_ctf_field_type_integer_get_size(struct bt_ctf_field_type *integer);
 
 /*
- * bt_ctf_field_type_integer_get_base: get an integer type's base.
- *
- * Get an integer type's base used to pretty-print the resulting trace.
- *
- * @param integer Integer type.
- *
- * Returns the integer type's base on success, BT_CTF_INTEGER_BASE_UNKNOWN on
- *	error.
- */
-BT_HIDDEN
-enum bt_ctf_integer_base bt_ctf_field_type_integer_get_base(
-		struct bt_ctf_field_type *integer);
-
-/*
  * bt_ctf_field_type_integer_get_encoding: get an integer type's encoding.
  *
  * @param integer Integer type.

--- a/include/babeltrace/ctf-ir/field-types.h
+++ b/include/babeltrace/ctf-ir/field-types.h
@@ -110,6 +110,19 @@ extern int bt_ctf_field_type_integer_set_signed(
 		struct bt_ctf_field_type *integer, int is_signed);
 
 /*
+ * bt_ctf_field_type_integer_get_base: get an integer type's base.
+ *
+ * Get an integer type's base used to pretty-print the resulting trace.
+ *
+ * @param integer Integer type.
+ *
+ * Returns the integer type's base on success, BT_CTF_INTEGER_BASE_UNKNOWN on
+ *     error.
+ */
+extern enum bt_ctf_integer_base bt_ctf_field_type_integer_get_base(
+		struct bt_ctf_field_type *integer);
+
+/*
  * bt_ctf_field_type_integer_set_base: set an integer type's base.
  *
  * Set an integer type's base used to pretty-print the resulting trace.

--- a/include/babeltrace/ctf-ir/field-types.h
+++ b/include/babeltrace/ctf-ir/field-types.h
@@ -136,6 +136,19 @@ extern int bt_ctf_field_type_integer_set_base(struct bt_ctf_field_type *integer,
 		enum bt_ctf_integer_base base);
 
 /*
+ * bt_ctf_field_type_string_get_encoding: get a string type's encoding.
+ *
+ * Get the string type's encoding.
+ *
+ * @param string_type String type.
+ *
+ * Returns the string's encoding on success, a BT_CTF_STRING_ENCODING_UNKNOWN
+ * on error.
+ */
+enum bt_ctf_string_encoding bt_ctf_field_type_string_get_encoding(
+		struct bt_ctf_field_type *string_type);
+
+/*
  * bt_ctf_field_type_integer_set_encoding: set an integer type's encoding.
  *
  * An integer encoding may be set to signal that the integer must be printed as

--- a/include/babeltrace/types.h
+++ b/include/babeltrace/types.h
@@ -449,6 +449,7 @@ struct declaration_enum *
 struct declaration_string *
 	bt_string_declaration_new(enum ctf_string_encoding encoding);
 char *bt_get_string(const struct bt_definition *field);
+char *bt_get_sequence_text(const struct bt_definition *field);
 enum ctf_string_encoding bt_get_string_encoding(const struct bt_definition *field);
 
 double bt_get_float(const struct bt_definition *field);

--- a/types/string.c
+++ b/types/string.c
@@ -129,3 +129,13 @@ char *bt_get_string(const struct bt_definition *field)
 
 	return string_definition->value;
 }
+
+char *bt_get_sequence_text(const struct bt_definition *field)
+{
+	struct definition_sequence *sequence_definition =
+		container_of(field, struct definition_sequence, p);
+
+	assert(sequence_definition->string != NULL);
+
+	return sequence_definition->string->str;
+}


### PR DESCRIPTION
These two functions are useful when you want to write a custom CTF analyzer using libbacktrace