### PR TITLE
bugfix babeltrace live was failing to connect if hostname had _

### DIFF
--- a/formats/lttng-live/lttng-live-plugin.c
+++ b/formats/lttng-live/lttng-live-plugin.c
@@ -180,7 +180,7 @@ int parse_url(const char *path, struct lttng_live_ctx *ctx)
 		ret = 0;
 		goto end;
 	}
-	ret = sscanf(remain[2], "host/%[a-zA-Z.0-9%-]/%s",
+	ret = sscanf(remain[2], "host/%[a-zA-Z.0-9_%-]/%s",
 			ctx->traced_hostname, ctx->session_name);
 	if (ret != 2) {
 		fprintf(stderr, "[error] Format : "


### PR DESCRIPTION
The reason was that a sscanf was failing the pattern match. After adding _ to the set, I was able to successfully view a live LTTng trace stream on a system that had _ in the hostname.