### PR TITLE
`swig -swiglib` returns multiple paths

### DIFF
--- a/m4/ax_pkg_swig.m4
+++ b/m4/ax_pkg_swig.m4
@@ -121,7 +121,7 @@ AC_DEFUN([AX_PKG_SWIG],[
                                 m4_ifval([$3],[$3],[])
                         else
                                 AC_MSG_CHECKING([for SWIG library])
-                                SWIG_LIB=`$SWIG -swiglib`
+                                SWIG_LIB=`$SWIG -swiglib | tail -1`
                                 AC_MSG_RESULT([$SWIG_LIB])
                                 m4_ifval([$2],[$2],[])
                         fi


### PR DESCRIPTION
When trying to build python-bindings under windows, using MSYS2, mutliple paths were returned when populating SWIG_LIB by `swig -swiglib`, breaking MAKEFILE generation in the process as SWIG_LIB was written incorrectly:

> SWIG_LIB=<first_path>
<second_path>

Adding `tail -1`, just the last path is preserved and SWIG_LIB is written properly @ generated MAKEFILE.
Not sure if this is the best solution as I'm no autotools expert.