### PR TITLE
ctf: Support enum values as bit fields

### DIFF
--- a/src/lib/trace-ir/field-class.h
+++ b/src/lib/trace-ir/field-class.h
@@ -290,6 +290,13 @@ struct bt_field_class_enumeration {
 	 * The actual strings are owned by the mappings above.
 	 */
 	GPtrArray *label_buf;
+
+	/*
+	 * This value caches whether the mapping values represent a bit field,
+	 * ie if all mappings have a unique value power of 2. In this case, the
+	 * mapping labels will correspond to the bits set to 1 in the value.
+	 */
+	uint8_t is_bit_field_enum;
 };
 
 struct bt_field_class_real {


### PR DESCRIPTION
When enum mapping values are all powers of 2, the value is considered as
a bit field value and the corresponding mappings should be all those
with this bit set to 1.

Example babeltrace output of such a field (block_rq* kernel events):

[13:15:49.024354958] (+0.000003868) wilbrod block_rq_complete: { cpu_id = 4 },
    { dev = 8388624, sector = 375490176, nr_sector = 360, error = 0,
      rwbs = ( "RWBS_FLAG_READ", "RWBS_FLAG_RAHEAD" : container = 12 ) }

Signed-off-by: Geneviève Bastien <gbastien@versatic.net>