### PR TITLE
Preserve ctf_{sequence,array}_text string data even if they contain NULL characters

### DIFF
--- a/src/plugins/ctf/common/msg-iter/msg-iter.c
+++ b/src/plugins/ctf/common/msg-iter/msg-iter.c
@@ -2049,11 +2049,6 @@ enum bt_bfcr_status bfcr_unsigned_int_char_cb(uint64_t value,
 		goto end;
 	}
 
-	if (value == 0) {
-		msg_it->done_filling_string = true;
-		goto end;
-	}
-
 	string_field = stack_top(msg_it->stack)->base;
 	BT_ASSERT_DBG(bt_field_get_class_type(string_field) ==
 		BT_FIELD_CLASS_TYPE_STRING);


### PR DESCRIPTION
This patch restores the behavior of babeltrace2 to that of babeltrace1.5 regarding the handling of ctf_sequence_text and ctf_array_text. The original bytes/length provided during tracing are reflected in the resulting string irrespective of it containing `'\0'` characters.

If the project is willing to accept the pull request I could devise a test to ensure this behavior is preserved in the future.