### PR TITLE
tests/lib/test_trace_ir_ref.c: rename user structure

### DIFF
--- a/tests/lib/test_trace_ir_ref.c
+++ b/tests/lib/test_trace_ir_ref.c
@@ -25,7 +25,7 @@
 
 #define NR_TESTS 37
 
-struct user {
+struct bt_user {
 	bt_trace_class *tc;
 	bt_stream_class *sc;
 	bt_event_class *ec;
@@ -265,7 +265,7 @@ static void test_example_scenario(bt_self_component_source *self_comp)
 	bt_stream_class *weak_sc1 = NULL, *weak_sc2 = NULL;
 	bt_event_class *weak_ec1 = NULL, *weak_ec2 = NULL,
 			*weak_ec3 = NULL;
-	struct user user_a = { 0 }, user_b = { 0 }, user_c = { 0 };
+	struct bt_user user_a = { 0 }, user_b = { 0 }, user_c = { 0 };
 
 	/* The only reference which exists at this point is on TC1. */
 	tc1 = create_tc1(self_comp);


### PR DESCRIPTION
Rename user structure to bt_user to avoid the following build failure
with uclibc:

```
test_trace_ir_ref.c:41:8: error: redefinition of 'struct user'
 struct user {
        ^
In file included from /home/naourr/work/instance-0/output-1/per-package/babeltrace2/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/include/sys/procfs.h:33,
                 from /home/naourr/work/instance-0/output-1/per-package/babeltrace2/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/include/sys/ucontext.h:25,
                 from /home/naourr/work/instance-0/output-1/per-package/babeltrace2/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/include/signal.h:329,
                 from /home/naourr/work/instance-0/output-1/per-package/babeltrace2/host/bin/../arm-buildroot-linux-uclibcgnueabi/sysroot/usr/include/glib-2.0/glib/gbacktrace.h:36,
                 from /home/naourr/work/instance-0/output-1/per-package/babeltrace2/host/bin/../arm-buildroot-linux-uclibcgnueabi/sysroot/usr/include/glib-2.0/glib.h:34,
                 from ../../src/common/assert.h:28,
                 from ../../src/lib/object.h:28,
                 from test_trace_ir_ref.c:25:
/home/naourr/work/instance-0/output-1/per-package/babeltrace2/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/include/sys/user.h:48:8: note: originally defined here
 struct user
        ^~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/e4229e2b9c892b419a9d2eaa6929b80ea62dd130

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>