### PR TITLE
ctf-writer: Fix list of reserved keywords

### DIFF
--- a/src/ctf-writer/utils.c
+++ b/src/ctf-writer/utils.c
@@ -25,7 +25,7 @@ const char * const reserved_keywords_str[] = {"align", "callsite",
 	"const", "char", "clock", "double", "enum", "env", "event",
 	"floating_point", "float", "integer", "int", "long", "short", "signed",
 	"stream", "string", "struct", "trace", "typealias", "typedef",
-	"unsigned", "variant", "void" "_Bool", "_Complex", "_Imaginary"};
+	"unsigned", "variant", "void", "_Bool", "_Complex", "_Imaginary"};
 
 static GHashTable *reserved_keywords_set;
 static int init_done;


### PR DESCRIPTION
The missing comma between "void" and "_Bool" causes the compiler to
treat it as one string ("void_Bool"), missing both "void" and "_Bool"
as real reserved keywords.

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>