### PR TITLE
Fix the build with slibtool

### DIFF
--- a/formats/ctf-text/Makefile.am
+++ b/formats/ctf-text/Makefile.am
@@ -12,9 +12,7 @@ libbabeltrace_ctf_text_la_LDFLAGS = \
 	$(LD_NO_AS_NEEDED) -version-info $(BABELTRACE_LIBRARY_VERSION) \
 	types/libctf-text-types.la
 
-libbabeltrace_ctf_text_la_LIBADD = \
-	$(top_builddir)/lib/libbabeltrace.la \
-	$(top_builddir)/formats/ctf/libbabeltrace-ctf.la
+libbabeltrace_ctf_text_la_LIBADD =
 
 if ENABLE_DEBUG_INFO
 libbabeltrace_ctf_text_la_LIBADD += $(top_builddir)/lib/libdebug-info.la

--- a/formats/ctf-text/types/Makefile.am
+++ b/formats/ctf-text/types/Makefile.am
@@ -14,5 +14,4 @@ libctf_text_types_la_SOURCES = \
 
 libctf_text_types_la_LDFLAGS = $(LT_NO_UNDEFINED)
 
-libctf_text_types_la_LIBADD = \
-	$(top_builddir)/lib/libbabeltrace.la
+libctf_text_types_la_LIBADD =

--- a/formats/ctf/Makefile.am
+++ b/formats/ctf/Makefile.am
@@ -17,7 +17,6 @@ libbabeltrace_ctf_la_LDFLAGS = \
 	$(LD_NO_AS_NEEDED) -version-info $(BABELTRACE_LIBRARY_VERSION)
 
 libbabeltrace_ctf_la_LIBADD = \
-	$(top_builddir)/lib/libbabeltrace.la \
 	types/libctf-types.la \
 	metadata/libctf-parser.la \
 	metadata/libctf-ast.la \

--- a/formats/ctf/ir/Makefile.am
+++ b/formats/ctf/ir/Makefile.am
@@ -22,8 +22,7 @@ libctf_ir_la_SOURCES = \
 
 libctf_ir_la_LDFLAGS = $(LT_NO_UNDEFINED)
 
-libctf_ir_la_LIBADD = \
-	$(top_builddir)/lib/libbabeltrace.la
+libctf_ir_la_LIBADD =
 
 if BABELTRACE_BUILD_WITH_LIBUUID
 libctf_ir_la_LIBADD += -luuid

--- a/formats/ctf/metadata/Makefile.am
+++ b/formats/ctf/metadata/Makefile.am
@@ -24,7 +24,7 @@ libctf_ast_la_SOURCES = ctf-visitor-xml.c \
 		ctf-visitor-semantic-validator.c \
 		ctf-visitor-generate-io-struct.c
 libctf_ast_la_LIBADD = \
-	$(top_builddir)/lib/libbabeltrace.la
+	$(top_builddir)/types/libbabeltrace_types.la
 libctf_ast_la_LDFLAGS = $(LT_NO_UNDEFINED)
 
 if BABELTRACE_BUILD_WITH_LIBUUID

--- a/formats/ctf/types/Makefile.am
+++ b/formats/ctf/types/Makefile.am
@@ -14,5 +14,4 @@ libctf_types_la_SOURCES = \
 
 libctf_types_la_LDFLAGS = $(LT_NO_UNDEFINED)
 
-libctf_types_la_LIBADD = \
-	$(top_builddir)/lib/libbabeltrace.la
+libctf_types_la_LIBADD =

--- a/formats/ctf/writer/Makefile.am
+++ b/formats/ctf/writer/Makefile.am
@@ -6,8 +6,7 @@ libctf_writer_la_SOURCES = \
 	writer.c \
 	functor.c
 
-libctf_writer_la_LIBADD = \
-	$(top_builddir)/lib/libbabeltrace.la
+libctf_writer_la_LIBADD =
 
 libctf_writer_la_LDFLAGS = $(LT_NO_UNDEFINED)
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -28,6 +28,4 @@ libdebug_info_la_LIBADD = libbabeltrace.la
 endif
 
 libbabeltrace_la_LIBADD = \
-	prio_heap/libprio_heap.la \
-	$(top_builddir)/types/libbabeltrace_types.la \
-	$(top_builddir)/compat/libcompat.la
+	prio_heap/libprio_heap.la


### PR DESCRIPTION
gentoo bug: https://bugs.gentoo.org/777444

Note:
* This PR is based against the `stable-1.5` branch.
* The current `master` branch is not affected.
* Gentoo still ships Babletrace 1 and does not yet have Babletrace 2. I have no knowledge when this will change.

The Babeltrace 1 build fails when using slibtool (https://dev.midipix.org/cross/slibtool) instead of GNU libtool with many multiple definition warnings. This appears to be a case of overlinking and can be solved by cleaning up the `.la` dependencies for the build. Slibtool is more sensitive to user error while GNU libtool will silently hide some of the worst bugs which is how this goes unnoticed. With this patch it now works with both slibtool and GNU libtool on my system. I am not sure if you wish to carry this patch too, but I am sharing it in case you find it valuable.