### PR TITLE
Make bt_field_blob_get_length return size_t instead of uint64_t

### DIFF
--- a/src/cpp-common/bt2/field.hpp
+++ b/src/cpp-common/bt2/field.hpp
@@ -1136,7 +1136,7 @@ public:
 
     bt2s::span<typename internal::CommonBlobFieldSpec<LibObjT>::Data> data() const noexcept
     {
-        return {internal::CommonBlobFieldSpec<LibObjT>::data(this->libObjPtr()), this->length()};
+        return {internal::CommonBlobFieldSpec<LibObjT>::data(this->libObjPtr()), static_cast<std::size_t>(this->length())};
     }
 
     std::uint64_t length() const noexcept


### PR DESCRIPTION
Fixes errors e.g.
| ../../git/src/cpp-common/bt2/field.hpp:1139:82: error: non-constant-expression cannot be narrowed from type 'std::uint64_t' (aka 'unsigned long long') to 'size_type' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
|  1139 |         return {internal::CommonBlobFieldSpec<LibObjT>::data(this->libObjPtr()), this->length()};
|       |                                                                                  ^~~~~~~~~~~~~~
| ../../git/src/plugins/ctf/common/src/msg-iter.cpp:744:56: note: in instantiation of member function 'bt2::CommonBlobField<bt_field>::data' requested here
|   744 |     std::memcpy(&this->_stackTopCurSubField().asBlob().data()[_mCurBlobFieldDataOffset],
|       |                                                        ^
| ../../git/src/cpp-common/bt2/field.hpp:1139:82: note: insert an explicit cast to silence this issue
|  1139 |         return {internal::CommonBlobFieldSpec<LibObjT>::data(this->libObjPtr()), this->length()};
|       |                                                                                  ^~~~~~~~~~~~~~
|       |                                                                                  static_cast<size_type>( )