### PR TITLE
Fix: trimmer: directly use provided value if integer

### DIFF
--- a/src/plugins/utils/trimmer/trimmer.c
+++ b/src/plugins/utils/trimmer/trimmer.c
@@ -445,13 +445,9 @@ int set_bound_from_param(struct trimmer_comp *trimmer_comp,
 
 	if (bt_value_is_signed_integer(param)) {
 		int64_t value = bt_value_integer_signed_get(param);
-
-		/*
-		 * Just convert it to a temporary string to handle
-		 * everything the same way.
-		 */
-		snprintf(tmp_arg, sizeof(tmp_arg), "%" PRId64, value);
-		arg = tmp_arg;
+		bound->ns_from_origin = value;
+		bound->is_set = true;
+		return 0;
 	} else {
 		BT_ASSERT(bt_value_is_string(param));
 		arg = bt_value_string_get(param);


### PR DESCRIPTION
The trimmer plugin allows to specify the filter begin and end as signed integer as well as timestring. When providing the value as integer, we cannot simply convert the number to a string, as the date parser does not accept this format. This is anyways not needed, as the API clearly states that signed integers (typed) are directly used as time in nanoseconds.

We fix this by directly processing the value in case it is a signed integer.

Fixes: 7de0e49a7 ("Adapt `flt.utils.trimmer` to current API")